### PR TITLE
fix: WiFi toggle, antenna mode, and band selection improvements

### DIFF
--- a/src/app/(tabs)/settings.tsx
+++ b/src/app/(tabs)/settings.tsx
@@ -39,18 +39,41 @@ const NETWORK_MODES = [
   { value: '0302', labelKey: 'settings.network4g3g' },
 ];
 
-// LTE Band definitions (common bands)
+// LTE Band definitions - Comprehensive FDD and TDD bands
 const LTE_BANDS = [
-  { bit: 0, name: 'B1', freq: '2100 MHz' },
-  { bit: 2, name: 'B3', freq: '1800 MHz' },
-  { bit: 4, name: 'B5', freq: '850 MHz' },
-  { bit: 6, name: 'B7', freq: '2600 MHz' },
-  { bit: 7, name: 'B8', freq: '900 MHz' },
-  { bit: 19, name: 'B20', freq: '800 MHz' },
-  { bit: 27, name: 'B28', freq: '700 MHz' },
-  { bit: 37, name: 'B38', freq: '2600 MHz TDD' },
-  { bit: 39, name: 'B40', freq: '2300 MHz TDD' },
-  { bit: 40, name: 'B41', freq: '2500 MHz TDD' },
+  // === FDD Bands ===
+  { bit: 0, name: 'B1', freq: '2100 MHz', region: 'Global' },
+  { bit: 1, name: 'B2', freq: '1900 MHz', region: 'Americas' },
+  { bit: 2, name: 'B3', freq: '1800 MHz', region: 'Global' },
+  { bit: 3, name: 'B4', freq: '1700/2100 MHz', region: 'Americas' },
+  { bit: 4, name: 'B5', freq: '850 MHz', region: 'Americas/Asia' },
+  { bit: 6, name: 'B7', freq: '2600 MHz', region: 'Global' },
+  { bit: 7, name: 'B8', freq: '900 MHz', region: 'Europe/Asia' },
+  { bit: 11, name: 'B12', freq: '700 MHz', region: 'Americas' },
+  { bit: 12, name: 'B13', freq: '700 MHz', region: 'Americas' },
+  { bit: 16, name: 'B17', freq: '700 MHz', region: 'Americas' },
+  { bit: 17, name: 'B18', freq: '850 MHz', region: 'Japan' },
+  { bit: 18, name: 'B19', freq: '850 MHz', region: 'Japan' },
+  { bit: 19, name: 'B20', freq: '800 MHz', region: 'Europe' },
+  { bit: 20, name: 'B21', freq: '1500 MHz', region: 'Japan' },
+  { bit: 24, name: 'B25', freq: '1900 MHz', region: 'Americas' },
+  { bit: 25, name: 'B26', freq: '850 MHz', region: 'Americas' },
+  { bit: 27, name: 'B28', freq: '700 MHz', region: 'Asia Pacific' },
+  { bit: 28, name: 'B29', freq: '700 MHz SDL', region: 'Americas' },
+  { bit: 29, name: 'B30', freq: '2300 MHz', region: 'Americas' },
+  { bit: 31, name: 'B32', freq: '1500 MHz SDL', region: 'Europe' },
+  { bit: 65, name: 'B66', freq: '1700/2100 MHz', region: 'Americas' },
+  { bit: 70, name: 'B71', freq: '600 MHz', region: 'Americas' },
+  // === TDD Bands ===
+  { bit: 33, name: 'B34', freq: '2010 MHz TDD', region: 'China' },
+  { bit: 37, name: 'B38', freq: '2600 MHz TDD', region: 'Global' },
+  { bit: 38, name: 'B39', freq: '1900 MHz TDD', region: 'China' },
+  { bit: 39, name: 'B40', freq: '2300 MHz TDD', region: 'Global' },
+  { bit: 40, name: 'B41', freq: '2500 MHz TDD', region: 'Global' },
+  { bit: 41, name: 'B42', freq: '3500 MHz TDD', region: 'Global' },
+  { bit: 42, name: 'B43', freq: '3700 MHz TDD', region: 'Global' },
+  { bit: 45, name: 'B46', freq: '5200 MHz LAA', region: 'Global' },
+  { bit: 47, name: 'B48', freq: '3600 MHz CBRS', region: 'Americas' },
 ];
 
 // NTP Servers

--- a/src/services/modem.service.ts
+++ b/src/services/modem.service.ts
@@ -253,7 +253,21 @@ export class ModemService {
   async getAntennaMode(): Promise<string> {
     try {
       const response = await this.apiClient.get('/api/device/antenna_type');
-      return parseXMLValue(response, 'antenna_type') || 'auto';
+      const antennaValue = parseXMLValue(response, 'antenna_type') ||
+        parseXMLValue(response, 'AntennaType') ||
+        parseXMLValue(response, 'antennatype');
+
+      // Map numeric values to string values
+      const modeMap: Record<string, string> = {
+        '0': 'auto',
+        '1': 'internal',
+        '2': 'external',
+        'auto': 'auto',
+        'internal': 'internal',
+        'external': 'external',
+      };
+
+      return modeMap[antennaValue] || 'auto';
     } catch (error) {
       console.error('Error getting antenna mode:', error);
       return 'auto'; // Default to auto if endpoint not available


### PR DESCRIPTION
Bug fixes:
- WiFi toggle: Added fallback endpoint (/api/wlan/basic-settings) when primary endpoint (/api/wlan/wifi-switch) fails

- Antenna mode: Fixed value parsing to handle multiple tag name variations and map numeric values (0/1/2) to string values

- Band selection modal:
  - Expanded from 10 to 30+ comprehensive LTE FDD/TDD bands
  - Added region info display (Global, Americas, Europe, Asia, etc)
  - Fixed BigInt usage for bit positions > 31 (B66: bit 65, B71: bit 70)
  - Updated loadBands, handleSave, and getSelectedBandsDisplay functions

Files modified:
- src/services/wifi.service.ts
- src/services/modem.service.ts
- src/components/BandSelectionModal.tsx
- src/app/(tabs)/settings.tsx