### PR TITLE
feat: Add monthly quota settings, i18n duration format, WiFi toggle improvements

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -329,14 +329,14 @@ jobs:
             ---
             
             ### Downloads
-            - **arm64-v8a** - For modern 64-bit devices (recommended)
-            - **armeabi-v7a** - For older 32-bit devices
-            - **universal** - Works on all devices (larger size)
+            - **arm64-v8a** - Untuk perangkat 64-bit (rekomended)
+            - **armeabi-v7a** - Untuk perangkat 32-bit
+            - **universal** - Bisa diinstall di semua perangkat (ukuran lebih besar)
             
-            ### Installation
-            1. Download the appropriate APK for your device
-            2. Enable "Install from unknown sources" in Settings
-            3. Open the APK file to install
+            ### Instalasi
+            1. Download APK yang sesuai dengan perangkat Anda
+            2. Enable "Install from unknown sources" di Settings
+            3. Buka file APK untuk menginstall
           files: apks/*.apk
           draft: false
           prerelease: false

--- a/.github/workflows/download-stats.yml
+++ b/.github/workflows/download-stats.yml
@@ -1,0 +1,53 @@
+name: Update Download Stats
+
+on:
+  schedule:
+    - cron: "0 */6 * * *"
+  workflow_dispatch:
+
+jobs:
+  stats:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Fetch release downloads
+        run: |
+          curl -s https://api.github.com/repos/${{ github.repository }}/releases \
+          | jq '
+            [
+              .[] |
+              {
+                tag: .tag_name,
+                total: (.assets | map(.download_count) | add)
+              }
+            ]
+          ' > stats/downloads.json
+
+      - name: Append history
+        run: |
+          TOTAL=$(jq '[.[].total] | add' stats/downloads.json)
+          DATE=$(date -u +"%Y-%m-%d %H:%M")
+          echo "$DATE,$TOTAL" >> stats/history.csv
+
+      - name: Generate chart (SVG)
+        run: |
+          sudo apt install -y gnuplot
+          gnuplot <<EOF
+          set terminal svg size 800,400
+          set output "stats/chart.svg"
+          set datafile separator ","
+          set xdata time
+          set timefmt "%Y-%m-%d %H:%M"
+          set format x "%d-%m"
+          set title "GitHub Release Downloads"
+          plot "stats/history.csv" using 1:2 with lines title "Downloads"
+          EOF
+
+      - name: Commit stats
+        run: |
+          git config user.name "github-actions"
+          git config user.email "actions@github.com"
+          git add stats/
+          git commit -m "chore: update download stats" || exit 0
+          git push

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ eas build --profile preview --platform android
 | [Architecture](docs/ARCHITECTURE.md) | Tech stack & project structure |
 | [User Guide](docs/USER_GUIDE.md) | Cara penggunaan aplikasi |
 | [API Reference](docs/API_REFERENCE.md) | Huawei modem API endpoints |
-| [Reverse engineering Web UI](devtools/README.md) | Reverse engineering Web UI |
+| [Devtools](devtools/README.md) | Reverse engineering Web UI |
 
 ---
 
@@ -149,38 +149,18 @@ Menemukan bug? Bantu kami memperbaikinya dengan melaporkan issue di GitHub:
 
 [![Report Bug](https://img.shields.io/badge/Report-Bug-red?style=for-the-badge&logo=github)](https://github.com/alrescha79-cmd/huawei-manager-mobile/issues/new?assignees=alrescha79-cmd&labels=bug&projects=&template=bug_report.md&title=%5BBUG%5D+)
 
-**Template Bug Report:**
-```
-**Deskripsi Bug**
-Jelaskan bug yang ditemukan secara singkat.
-
-**Langkah Reproduksi**
-1. Buka '...'
-2. Klik '...'
-3. Scroll ke '...'
-4. Lihat error
-
-**Perilaku yang Diharapkan**
-Jelaskan apa yang seharusnya terjadi.
-
-**Screenshots**
-Jika memungkinkan, tambahkan screenshot.
-
-**Informasi Device:**
-- Device: [e.g. Samsung Galaxy A52]
-- OS: [e.g. Android 13]
-- App Version: [e.g. 1.0.25]
-- Modem: [e.g. Huawei B312-929]
-
-**Informasi Tambahan**
-Tambahkan konteks lain tentang bug di sini.
-```
 
 ---
 
 ## 📄 License
 
-MIT License - see [LICENSE](LICENSE) file
+MIT License - see [LICENSE](LICENSE)
+
+---
+
+## 📈 Download History
+
+![Download Chart](stats/chart.svg)
 
 ---
 

--- a/src/app/(tabs)/wifi.tsx
+++ b/src/app/(tabs)/wifi.tsx
@@ -216,13 +216,45 @@ export default function WiFiScreen() {
   };
 
   const handleToggleWiFi = async (enabled: boolean) => {
+    console.log('[WiFi UI] handleToggleWiFi called, enabled:', enabled);
+    console.log('[WiFi UI] wifiService:', wifiService);
+    if (!wifiService) {
+      console.log('[WiFi UI] wifiService is null, returning');
+      return;
+    }
+
+    // Show confirmation alert when turning OFF WiFi
+    if (!enabled) {
+      ThemedAlertHelper.alert(
+        t('wifi.disableWifiTitle'),
+        t('wifi.disableWifiWarning'),
+        [
+          { text: t('common.cancel'), style: 'cancel' },
+          {
+            text: t('common.confirm'),
+            style: 'destructive',
+            onPress: async () => {
+              await performToggleWiFi(enabled);
+            },
+          },
+        ]
+      );
+    } else {
+      await performToggleWiFi(enabled);
+    }
+  };
+
+  const performToggleWiFi = async (enabled: boolean) => {
     if (!wifiService) return;
 
     try {
+      console.log('[WiFi UI] Calling wifiService.toggleWiFi...');
       await wifiService.toggleWiFi(enabled);
+      console.log('[WiFi UI] toggleWiFi completed successfully');
       ThemedAlertHelper.alert(t('common.success'), enabled ? t('wifi.wifiEnabled') : t('wifi.wifiDisabled'));
       handleRefresh();
     } catch (error) {
+      console.error('[WiFi UI] toggleWiFi error:', error);
       ThemedAlertHelper.alert(t('common.error'), t('alerts.failedToggleWifi'));
     }
   };
@@ -325,18 +357,32 @@ export default function WiFiScreen() {
   };
 
   const handleSaveSettings = async () => {
-    if (!wifiService || !hasChanges || isSaving) return;
+    console.log('[WiFi UI] handleSaveSettings called');
+    console.log('[WiFi UI] wifiService:', wifiService);
+    console.log('[WiFi UI] hasChanges:', hasChanges);
+    console.log('[WiFi UI] isSaving:', isSaving);
+    console.log('[WiFi UI] formSsid:', formSsid);
+    console.log('[WiFi UI] formPassword:', formPassword);
+    console.log('[WiFi UI] formSecurityMode:', formSecurityMode);
+
+    if (!wifiService || !hasChanges || isSaving) {
+      console.log('[WiFi UI] Early return - conditions not met');
+      return;
+    }
 
     setIsSaving(true);
     try {
+      console.log('[WiFi UI] Calling wifiService.setWiFiSettings...');
       await wifiService.setWiFiSettings({
         ssid: formSsid,
         password: formPassword,
         securityMode: formSecurityMode,
       });
+      console.log('[WiFi UI] setWiFiSettings completed successfully');
       ThemedAlertHelper.alert(t('common.success'), t('wifi.settingsSaved'));
       handleRefresh();
     } catch (error) {
+      console.error('[WiFi UI] setWiFiSettings error:', error);
       ThemedAlertHelper.alert(t('common.error'), t('alerts.failedSaveWifi'));
     } finally {
       setIsSaving(false);

--- a/src/components/UsageCard.tsx
+++ b/src/components/UsageCard.tsx
@@ -12,6 +12,7 @@ interface UsageCardProps {
     duration?: number;
     color: 'cyan' | 'emerald' | 'amber' | 'fuchsia';
     icon: keyof typeof MaterialIcons.glyphMap;
+    totalOnly?: boolean;  // Hide download/upload breakdown, show only total
 }
 
 // Helper to format bytes with separate value and unit
@@ -38,7 +39,8 @@ export function UsageCard({
     upload,
     duration,
     color,
-    icon
+    icon,
+    totalOnly = false
 }: UsageCardProps) {
     const { colors, typography, spacing } = useTheme();
 
@@ -117,27 +119,29 @@ export function UsageCard({
                 </Text>
             )}
 
-            {/* Stats Grid */}
-            <View style={[styles.statsGrid, { borderTopColor: colors.border }]}>
-                <View style={styles.statItem}>
-                    <Text style={[styles.statLabel, { color: colors.textSecondary }]}>Download</Text>
-                    <View style={styles.statValue}>
-                        <MaterialIcons name="arrow-downward" size={12} color="#22d3ee" />
-                        <Text style={[styles.statText, { color: '#22d3ee' }]}>
-                            {dlFormatted.value} {dlFormatted.unit}
-                        </Text>
+            {/* Stats Grid - hidden when totalOnly */}
+            {!totalOnly && (
+                <View style={[styles.statsGrid, { borderTopColor: colors.border }]}>
+                    <View style={styles.statItem}>
+                        <Text style={[styles.statLabel, { color: colors.textSecondary }]}>Download</Text>
+                        <View style={styles.statValue}>
+                            <MaterialIcons name="arrow-downward" size={12} color="#22d3ee" />
+                            <Text style={[styles.statText, { color: '#22d3ee' }]}>
+                                {dlFormatted.value} {dlFormatted.unit}
+                            </Text>
+                        </View>
+                    </View>
+                    <View style={styles.statItem}>
+                        <Text style={[styles.statLabel, { color: colors.textSecondary }]}>Upload</Text>
+                        <View style={styles.statValue}>
+                            <MaterialIcons name="arrow-upward" size={12} color="#e879f9" />
+                            <Text style={[styles.statText, { color: '#e879f9' }]}>
+                                {ulFormatted.value} {ulFormatted.unit}
+                            </Text>
+                        </View>
                     </View>
                 </View>
-                <View style={styles.statItem}>
-                    <Text style={[styles.statLabel, { color: colors.textSecondary }]}>Upload</Text>
-                    <View style={styles.statValue}>
-                        <MaterialIcons name="arrow-upward" size={12} color="#e879f9" />
-                        <Text style={[styles.statText, { color: '#e879f9' }]}>
-                            {ulFormatted.value} {ulFormatted.unit}
-                        </Text>
-                    </View>
-                </View>
-            </View>
+            )}
         </View>
     );
 }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -17,7 +17,11 @@
     "fetching": "Fetching...",
     "goToLogin": "Go to Login",
     "kick": "Kick",
-    "later": "Later"
+    "later": "Later",
+    "days": "d",
+    "hours": "h",
+    "minutes": "m",
+    "seconds": "s"
   },
   "alerts": {
     "newVersionAvailable": "A new version is available. Would you like to download it now?",
@@ -101,6 +105,8 @@
     "download": "Download",
     "upload": "Upload",
     "currentSession": "Session",
+    "dailyUsage": "Daily Usage",
+    "today": "Today",
     "monthlyUsage": "Monthly Usage",
     "totalUsage": "Total Usage",
     "downloadSpeed": "Download Speed",
@@ -177,6 +183,8 @@
     "securityWpa3": "WPA3-SAE",
     "wifiEnabled": "WiFi enabled",
     "wifiDisabled": "WiFi disabled",
+    "disableWifiTitle": "Turn Off WiFi?",
+    "disableWifiWarning": "Turning off WiFi will disconnect all wireless devices. You will need to use ethernet cable or physical button to reconnect. Are you sure?",
     "guestWifiEnabled": "Guest WiFi enabled",
     "guestWifiDisabled": "Guest WiFi disabled",
     "editSettings": "Edit WiFi Settings",
@@ -221,7 +229,8 @@
     "messageDeleted": "Message deleted",
     "messageSent": "Message sent",
     "fillAllFields": "Please fill in all fields",
-    "compose": "Compose"
+    "compose": "Compose",
+    "reply": "Reply"
   },
   "settings": {
     "modemInfo": "Modem Information",
@@ -384,7 +393,10 @@
     "ipType": "IP Type",
     "setAsDefaultHint": "Use this profile as default for mobile data",
     "default": "Default",
-    "apnRequired": "Profile name and APN are required"
+    "apnRequired": "Profile name and APN are required",
+    "monthlyQuota": "Monthly Data Quota",
+    "notSet": "Not set",
+    "configure": "Configure"
   },
   "timeSettings": {
     "title": "Time Settings",

--- a/src/i18n/id.json
+++ b/src/i18n/id.json
@@ -17,7 +17,11 @@
     "fetching": "Mengambil...",
     "goToLogin": "Ke Halaman Login",
     "kick": "Putuskan",
-    "later": "Nanti"
+    "later": "Nanti",
+    "days": "h",
+    "hours": "j",
+    "minutes": "m",
+    "seconds": "d"
   },
   "alerts": {
     "newVersionAvailable": "Versi baru tersedia. Apakah Anda ingin mengunduhnya sekarang?",
@@ -101,6 +105,8 @@
     "download": "Unduh",
     "upload": "Unggah",
     "currentSession": "Sesi",
+    "dailyUsage": "Penggunaan Harian",
+    "today": "Hari Ini",
     "monthlyUsage": "Penggunaan Bulanan",
     "totalUsage": "Total Penggunaan",
     "downloadSpeed": "Kecepatan Unduh",
@@ -177,6 +183,8 @@
     "securityWpa3": "WPA3-SAE",
     "wifiEnabled": "WiFi diaktifkan",
     "wifiDisabled": "WiFi dinonaktifkan",
+    "disableWifiTitle": "Matikan WiFi?",
+    "disableWifiWarning": "Mematikan WiFi akan memutuskan semua perangkat nirkabel. Anda perlu menggunakan kabel ethernet atau tombol fisik untuk menyambung kembali. Yakin ingin melanjutkan?",
     "guestWifiEnabled": "WiFi Tamu diaktifkan",
     "guestWifiDisabled": "WiFi Tamu dinonaktifkan",
     "editSettings": "Edit Pengaturan WiFi",
@@ -221,7 +229,8 @@
     "messageDeleted": "Pesan dihapus",
     "messageSent": "Pesan terkirim",
     "fillAllFields": "Mohon isi semua kolom",
-    "compose": "Tulis"
+    "compose": "Tulis",
+    "reply": "Balas"
   },
   "settings": {
     "modemInfo": "Informasi Modem",
@@ -384,7 +393,10 @@
     "ipType": "Tipe IP",
     "setAsDefaultHint": "Gunakan profil ini sebagai default untuk data seluler",
     "default": "Default",
-    "apnRequired": "Nama profil dan APN wajib diisi"
+    "apnRequired": "Nama profil dan APN wajib diisi",
+    "monthlyQuota": "Kuota Data Bulanan",
+    "notSet": "Belum diatur",
+    "configure": "Atur"
   },
   "timeSettings": {
     "title": "Pengaturan Waktu",

--- a/src/services/modem.service.ts
+++ b/src/services/modem.service.ts
@@ -113,10 +113,12 @@ export class ModemService {
       // Also fetch monthly stats from separate endpoint
       let monthDownload = 0;
       let monthUpload = 0;
+      let dayUsed = 0;
+      let dayDuration = 0;
       try {
         const monthResponse = await this.apiClient.get('/api/monitoring/month_statistics');
 
-        // Try different possible tag names
+        // Try different possible tag names for monthly
         monthDownload = safeParseInt(
           parseXMLValue(monthResponse, 'CurrentMonthDownload') ||
           parseXMLValue(monthResponse, 'monthDownload') ||
@@ -127,7 +129,21 @@ export class ModemService {
           parseXMLValue(monthResponse, 'monthUpload') ||
           parseXMLValue(monthResponse, 'MonthUpload')
         );
-      } catch {
+
+        // Parse daily usage (combined download + upload)
+        dayUsed = safeParseInt(
+          parseXMLValue(monthResponse, 'CurrentDayUsed') ||
+          parseXMLValue(monthResponse, 'dayUsed') ||
+          parseXMLValue(monthResponse, 'DayUsed')
+        );
+
+        // Parse daily duration (seconds)
+        dayDuration = safeParseInt(
+          parseXMLValue(monthResponse, 'CurrentDayDuration') ||
+          parseXMLValue(monthResponse, 'dayDuration') ||
+          parseXMLValue(monthResponse, 'DayDuration')
+        );
+      } catch (monthErr) {
         // Month statistics not available - continue without them
       }
 
@@ -142,6 +158,8 @@ export class ModemService {
         totalConnectTime: safeParseInt(parseXMLValue(response, 'TotalConnectTime')),
         monthDownload,
         monthUpload,
+        dayUsed,
+        dayDuration,
       };
     } catch (error) {
       console.error('Error getting traffic stats:', error);

--- a/src/services/sms.service.ts
+++ b/src/services/sms.service.ts
@@ -9,9 +9,20 @@ export class SMSService {
     this.apiClient = new ModemAPIClient(modemIp);
   }
 
-  async getSMSList(page: number = 1, count: number = 20): Promise<SMSMessage[]> {
+  async getSMSList(page: number = 1, count: number = 20, boxType: number = 1): Promise<SMSMessage[]> {
     try {
-      const response = await this.apiClient.get(`/api/sms/sms-list?page=${page}&count=${count}&sortType=0&readCount=0&boxType=1`);
+      // SMS list requires POST with XML body
+      const requestData = `<?xml version="1.0" encoding="UTF-8"?>
+        <request>
+          <PageIndex>${page}</PageIndex>
+          <ReadCount>${count}</ReadCount>
+          <BoxType>${boxType}</BoxType>
+          <SortType>0</SortType>
+          <Ascending>0</Ascending>
+          <UnreadPreferred>0</UnreadPreferred>
+        </request>`;
+
+      const response = await this.apiClient.post('/api/sms/sms-list', requestData);
 
       const messages: SMSMessage[] = [];
       // Use [\s\S] instead of . to properly match content including newlines

--- a/src/stores/modem.store.ts
+++ b/src/stores/modem.store.ts
@@ -4,6 +4,16 @@ import { ModemInfo, SignalInfo, NetworkInfo, TrafficStats, ModemStatus, WanInfo,
 
 const PREVIOUS_WAN_IP_KEY = 'previous_wan_ip';
 
+// Monthly data settings interface
+export interface MonthlySettings {
+  enabled: boolean;
+  startDay: number;
+  dataLimit: number;
+  dataLimitUnit: 'MB' | 'GB';
+  monthThreshold: number;
+  trafficMaxLimit?: number;
+}
+
 interface ModemState {
   modemInfo: ModemInfo | null;
   signalInfo: SignalInfo | null;
@@ -12,6 +22,7 @@ interface ModemState {
   modemStatus: ModemStatus | null;
   wanInfo: WanInfo | null;
   mobileDataStatus: MobileDataStatus | null;
+  monthlySettings: MonthlySettings | null;
   previousWanIp: string | null;
   isLoading: boolean;
   error: string | null;
@@ -23,6 +34,7 @@ interface ModemState {
   setModemStatus: (status: ModemStatus) => void;
   setWanInfo: (info: WanInfo) => void;
   setMobileDataStatus: (status: MobileDataStatus) => void;
+  setMonthlySettings: (settings: MonthlySettings | null) => void;
   setPreviousWanIp: (ip: string | null) => void;
   loadPreviousWanIp: () => Promise<void>;
   setLoading: (isLoading: boolean) => void;
@@ -38,6 +50,7 @@ export const useModemStore = create<ModemState>((set, get) => ({
   modemStatus: null,
   wanInfo: null,
   mobileDataStatus: null,
+  monthlySettings: null,
   previousWanIp: null,
   isLoading: false,
   error: null,
@@ -64,6 +77,8 @@ export const useModemStore = create<ModemState>((set, get) => ({
   },
 
   setMobileDataStatus: (status) => set({ mobileDataStatus: status }),
+
+  setMonthlySettings: (settings) => set({ monthlySettings: settings }),
 
   setPreviousWanIp: (ip) => {
     set({ previousWanIp: ip });

--- a/src/types/modem.types.ts
+++ b/src/types/modem.types.ts
@@ -63,6 +63,8 @@ export interface TrafficStats {
   totalConnectTime: number;
   monthDownload: number;
   monthUpload: number;
+  dayUsed: number;
+  dayDuration: number;
 }
 
 export interface ConnectedDevice {

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -21,20 +21,35 @@ export const formatBitsPerSecond = (bps: number): string => {
   return parseFloat((bps / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
 };
 
-export const formatDuration = (seconds: number): string => {
+export interface DurationUnits {
+  days: string;
+  hours: string;
+  minutes: string;
+  seconds: string;
+}
+
+// Default units (English short form)
+const defaultUnits: DurationUnits = {
+  days: 'd',
+  hours: 'h',
+  minutes: 'm',
+  seconds: 's',
+};
+
+export const formatDuration = (seconds: number, units: DurationUnits = defaultUnits): string => {
   const days = Math.floor(seconds / 86400);
   const hours = Math.floor((seconds % 86400) / 3600);
   const minutes = Math.floor((seconds % 3600) / 60);
   const secs = seconds % 60;
 
   if (days > 0) {
-    return `${days}d ${hours}h ${minutes}m`;
+    return `${days}${units.days} ${hours}${units.hours} ${minutes}${units.minutes}`;
   } else if (hours > 0) {
-    return `${hours}h ${minutes}m`;
+    return `${hours}${units.hours} ${minutes}${units.minutes}`;
   } else if (minutes > 0) {
-    return `${minutes}m ${secs}s`;
+    return `${minutes}${units.minutes} ${secs}${units.seconds}`;
   } else {
-    return `${secs}s`;
+    return `${secs}${units.seconds}`;
   }
 };
 


### PR DESCRIPTION


Changes:
- Add monthly quota settings to Settings page with API sync via shared store
- Implement i18n support for duration format (days, hours, minutes, seconds)
- Add WiFi toggle confirmation alert with warning when disabling
- Add debug logging for WiFi service methods
- Improve SMS list with delete functionality and refresh controls
- Update modem store with MonthlySettings interface for cross-page sync

Files modified:
- home.tsx: Use shared monthlySettings from store, i18n duration units
- settings.tsx: Add monthly quota UI in Mobile Network section
- wifi.tsx: Add confirmation dialog before disabling WiFi
- wifi.service.ts: Add debug logging, attempt multi-basic-settings toggle
- modem.store.ts: Add monthlySettings state and setter
- sms.tsx: Add delete SMS functionality
- helpers.ts: Update formatDuration with optional units parameter
- en.json, id.json: Add translations for monthly quota, WiFi disable warning, duration units