### PR TITLE
fix: improve SMS error handling, widget updates, and traffic stats tracking

### DIFF
--- a/.github/workflows/download-stats.yml
+++ b/.github/workflows/download-stats.yml
@@ -2,7 +2,7 @@ name: Update Download Stats
 
 on:  
   schedule:
-    - cron: "0 1 * * *"
+    - cron: "0 10 * * *"
   workflow_dispatch:
 
 jobs:  

--- a/app.config.ts
+++ b/app.config.ts
@@ -30,7 +30,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     ...config,
     name: 'Huawei Manager',
     slug: 'hm-mobile',
-    version: '1.0.65',
+    version: '1.0.75',
     orientation: 'portrait',
     icon: './assets/logo.png',
     userInterfaceStyle: 'automatic',

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Huawei Manager",
     "slug": "hm-mobile",
-    "version": "1.0.65",
+    "version": "1.0.75",
     "orientation": "portrait",
     "icon": "./assets/logo.png",
     "userInterfaceStyle": "automatic",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hm-mobile",
-  "version": "1.0.65",
+  "version": "1.0.75",
   "main": "index.js",
   "scripts": {
     "start": "expo start",

--- a/src/widget/ModemStatusWidget.tsx
+++ b/src/widget/ModemStatusWidget.tsx
@@ -156,7 +156,7 @@ export function ModemStatusWidget({ data }: ModemStatusWidgetProps) {
     const networkType = getNetworkTypeName(data.networkType);
     const signalStrength = parseInt(data.signalStrength || '0', 10);
 
-    const sessionTotal = data.sessionDownload + data.sessionUpload;
+    const sessionTotal = data.currentDownload + data.currentUpload;
     const monthTotal = data.monthDownload + data.monthUpload;
     const total = data.totalDownload + data.totalUpload;
 
@@ -258,7 +258,7 @@ export function ModemStatusWidget({ data }: ModemStatusWidgetProps) {
                     {/* Download Speed */}
                     <SpeedCard
                         icon="↓"
-                        speed={formatSpeed(data.downloadSpeed)}
+                        speed={formatSpeed(data.currentDownloadRate)}
                         label="Download"
                         iconColor={colors.blue}
                         iconBg={colors.blueBg}
@@ -267,7 +267,7 @@ export function ModemStatusWidget({ data }: ModemStatusWidgetProps) {
                     {/* Upload Speed - Same style as Download */}
                     <SpeedCard
                         icon="↑"
-                        speed={formatSpeed(data.uploadSpeed)}
+                        speed={formatSpeed(data.currentUploadRate)}
                         label="Upload"
                         iconColor={colors.orange}
                         iconBg={colors.orangeBg}
@@ -290,33 +290,33 @@ export function ModemStatusWidget({ data }: ModemStatusWidgetProps) {
                         valueColor={colors.textPrimary}
                     />
                     <UsageRow
+                        icon="◐"
+                        label="Daily"
+                        value={formatBytes(data.dayUsed)}
+                        valueColor={colors.orange}
+                    />
+                    <UsageRow
                         icon="▦"
                         label="Monthly"
                         value={formatBytes(monthTotal)}
                         valueColor={colors.yellow}
                     />
-                    <UsageRow
-                        icon="⬡"
-                        label="Total"
-                        value={formatBytes(total)}
-                        valueColor={colors.textSecondary}
-                    />
 
-                    {/* Progress Bar */}
+                    {/* Progress Bar - show monthly usage percentage */}
                     <FlexWidget
                         style={{
                             height: 6,
                             backgroundColor: colors.cardBg,
                             borderRadius: 3,
-                            marginTop: 4,
+                            marginTop: 6,
                             width: 'match_parent',
                         }}
                     >
                         <FlexWidget
                             style={{
-                                width: 70,
+                                width: `${Math.min((monthTotal / (50 * 1024 * 1024 * 1024)) * 100, 100)}%`,
                                 height: 6,
-                                backgroundColor: colors.blue,
+                                backgroundColor: monthTotal > 40 * 1024 * 1024 * 1024 ? colors.orange : colors.blue,
                                 borderRadius: 3,
                             }}
                         />

--- a/src/widget/WidgetUpdater.tsx
+++ b/src/widget/WidgetUpdater.tsx
@@ -1,51 +1,103 @@
 import React from 'react';
-import { requestWidgetUpdate } from 'react-native-android-widget';
+import { requestWidgetUpdate, requestWidgetUpdateById } from 'react-native-android-widget';
+import { AppState } from 'react-native';
+import type { AppStateStatus } from 'react-native';
 import { ModemStatusWidget } from './ModemStatusWidget';
 import { fetchWidgetData, fetchSpeedData, WidgetData } from './WidgetDataService';
 
 const WIDGET_NAME = 'ModemStatus';
+const SPEED_UPDATE_INTERVAL = 2000; // 2 seconds - balance between responsiveness and performance
+const FULL_UPDATE_INTERVAL = 30000; // 30 seconds
 
 let speedIntervalId: ReturnType<typeof setInterval> | null = null;
 let fullDataIntervalId: ReturnType<typeof setInterval> | null = null;
 let cachedFullData: WidgetData | null = null;
+let updateCount = 0;
+let isUpdating = false;
 
+/**
+ * Update widget with speed data only (fast update, ~2s interval)
+ * 
+ * IMPORTANT: No authentication required! Widget can update without login.
+ * Uses /api/monitoring/traffic-statistics endpoint which is publicly accessible.
+ * 
+ * Note: Uses a flag to prevent concurrent updates.
+ */
 async function updateWidgetWithSpeed(): Promise<void> {
+    // Prevent concurrent updates
+    if (isUpdating) {
+        return;
+    }
+
+    isUpdating = true;
     try {
         const speedData = await fetchSpeedData();
+        updateCount++;
 
+        // Merge speed data with cached full data
         const mergedData: WidgetData = cachedFullData
             ? {
                 ...cachedFullData,
-                downloadSpeed: speedData.downloadSpeed,
-                uploadSpeed: speedData.uploadSpeed,
-                sessionDownload: speedData.sessionDownload,
-                sessionUpload: speedData.sessionUpload,
+                currentDownloadRate: speedData.currentDownloadRate,
+                currentUploadRate: speedData.currentUploadRate,
+                currentDownload: speedData.currentDownload,
+                currentUpload: speedData.currentUpload,
                 lastUpdated: Date.now(),
             }
             : {
-                downloadSpeed: speedData.downloadSpeed,
-                uploadSpeed: speedData.uploadSpeed,
-                sessionDownload: speedData.sessionDownload,
-                sessionUpload: speedData.sessionUpload,
+                // Speed data
+                currentDownloadRate: speedData.currentDownloadRate,
+                currentUploadRate: speedData.currentUploadRate,
+                // Session data
+                currentDownload: speedData.currentDownload,
+                currentUpload: speedData.currentUpload,
+                currentConnectTime: 0,
+                // Monthly data
                 monthDownload: 0,
                 monthUpload: 0,
+                monthDuration: 0,
+                // Daily data
+                dayUsed: 0,
+                dayDuration: 0,
+                // Total data
                 totalDownload: 0,
                 totalUpload: 0,
+                totalConnectTime: 0,
+                // Connection info
                 connectionStatus: '901',
                 networkType: '19',
                 signalStrength: '5',
                 lastUpdated: Date.now(),
             };
 
+        // Use requestWidgetUpdate to force update
         await requestWidgetUpdate({
             widgetName: WIDGET_NAME,
             renderWidget: () => <ModemStatusWidget data={mergedData} />,
+            widgetNotExist: 'ignore', // Don't throw error if widget doesn't exist
         });
-    } catch {
-        // Silently fail
+
+        if (updateCount % 10 === 0) {
+            console.log(`[Widget] Speed update #${updateCount}: ${(speedData.currentDownloadRate / 1024 / 1024).toFixed(2)} MB/s down, ${(speedData.currentUploadRate / 1024 / 1024).toFixed(2)} MB/s up`);
+        }
+    } catch (error) {
+        if (updateCount % 10 === 0) {
+            console.log('[Widget] Speed update failed:', error);
+        }
+    } finally {
+        isUpdating = false;
     }
 }
 
+/**
+ * Update widget with full data (slower update, ~30s interval)
+ * 
+ * IMPORTANT: No authentication required! Widget can update without login.
+ * Fetches from multiple monitoring endpoints that are publicly accessible:
+ * - /api/monitoring/traffic-statistics
+ * - /api/monitoring/month_statistics
+ * - /api/monitoring/status
+ */
 async function updateWidgetWithFullData(): Promise<void> {
     try {
         cachedFullData = await fetchWidgetData();
@@ -53,9 +105,12 @@ async function updateWidgetWithFullData(): Promise<void> {
         await requestWidgetUpdate({
             widgetName: WIDGET_NAME,
             renderWidget: () => <ModemStatusWidget data={cachedFullData!} />,
+            widgetNotExist: 'ignore', // Don't throw error if widget doesn't exist
         });
-    } catch {
-        // Silently fail
+
+        console.log('[Widget] Full data update complete');
+    } catch (error) {
+        console.log('[Widget] Full data update failed:', error);
     }
 }
 
@@ -63,17 +118,44 @@ export async function updateModemWidget(): Promise<void> {
     await updateWidgetWithFullData();
 }
 
+/**
+ * Start realtime widget updates
+ * - Speed updates every 2 seconds (download/upload rates, session traffic)
+ * - Full data updates every 30 seconds (monthly, daily, total traffic, signal, etc)
+ * 
+ * IMPORTANT: Widget updates work WITHOUT authentication!
+ * The modem's monitoring endpoints are publicly accessible.
+ * 
+ * Note: 2-second interval provides good balance between responsiveness and performance.
+ * Widget will only update when app is in foreground to save battery.
+ * 
+ * @returns Function to stop updates
+ */
 export function startRealtimeWidgetUpdates(): () => void {
+    console.log('[Widget] Starting realtime updates...');
     stopRealtimeWidgetUpdates();
+    
+    // Reset counter and flag
+    updateCount = 0;
+    isUpdating = false;
+    
+    // Initial full update
     updateWidgetWithFullData();
 
+    // Speed updates every 2 seconds
     speedIntervalId = setInterval(() => {
-        updateWidgetWithSpeed();
-    }, 1000);
+        // Only update if app is active
+        if (AppState.currentState === 'active') {
+            updateWidgetWithSpeed();
+        }
+    }, SPEED_UPDATE_INTERVAL);
 
+    // Full data updates every 30 seconds
     fullDataIntervalId = setInterval(() => {
         updateWidgetWithFullData();
-    }, 30000);
+    }, FULL_UPDATE_INTERVAL);
+
+    console.log(`[Widget] Updates started: speed every ${SPEED_UPDATE_INTERVAL}ms, full every ${FULL_UPDATE_INTERVAL}ms`);
 
     return stopRealtimeWidgetUpdates;
 }
@@ -82,10 +164,12 @@ export function stopRealtimeWidgetUpdates(): void {
     if (speedIntervalId) {
         clearInterval(speedIntervalId);
         speedIntervalId = null;
+        console.log('[Widget] Speed updates stopped');
     }
 
     if (fullDataIntervalId) {
         clearInterval(fullDataIntervalId);
         fullDataIntervalId = null;
+        console.log('[Widget] Full updates stopped');
     }
 }


### PR DESCRIPTION
## SMS Service Improvements
- Add SMS support detection using sms-feature-switch endpoint
- Distinguish between "SMS not supported" and "session expired" errors
- Prevent unnecessary re-login when modem doesn't support SMS
- Add cache mechanism for SMS support status with reset capability
- Follow huawei-lte-api Python library implementation pattern

## Widget Enhancements
- Update widget data structure to match TrafficStats interface
- Add daily usage display to widget (Session, Daily, Monthly)
- Fix realtime speed updates (2-second interval for better performance)
- Add concurrent update prevention with isUpdating flag
- Implement app state check to only update when app is active
- Add comprehensive logging for debugging widget updates
- All widget endpoints work WITHOUT authentication

## Traffic Stats Auto-Detection
- Auto-detect when traffic history is cleared (from web or other apps)
- Track previous total traffic for comparison (> 100MB threshold)
- Show "Last Cleared" date automatically when 90% drop detected
- Persist cleared date and previous traffic to AsyncStorage
- Support both manual clear (from app) and external clear (from web interface)

## Technical Details
- Widget speed updates: every 2 seconds (when app active)
- Widget full updates: every 30 seconds
- SMS support cache: reset on credential change
- Traffic drop detection: < 10% of previous (with 100MB minimum)
- Error codes handled: 125003, 125002 (session errors)

Version: 1.0.75