### PR TITLE
feat: implement compact usage card and view settings

### DIFF
--- a/src/app/(tabs)/settings/index.tsx
+++ b/src/app/(tabs)/settings/index.tsx
@@ -19,10 +19,11 @@ export default function SettingsIndex() {
     const router = useRouter();
     const { colors, typography } = useTheme();
     const { t } = useTranslation();
-    const { themeMode, setThemeMode, language, setLanguage } = useThemeStore();
+    const { themeMode, setThemeMode, language, setLanguage, usageCardStyle, setUsageCardStyle } = useThemeStore();
 
     const [showThemeModal, setShowThemeModal] = React.useState(false);
     const [showLanguageModal, setShowLanguageModal] = React.useState(false);
+    const [showUsageModal, setShowUsageModal] = React.useState(false);
 
     const handleOpenGitHub = () => {
         Linking.openURL('https://github.com/alrescha79-cmd');
@@ -77,6 +78,24 @@ export default function SettingsIndex() {
                     title={t('settings.system')}
                     subtitle={t('settings.systemSubtitle') || 'Time, Reboot, Reset'}
                     onPress={() => router.push('/settings/system')}
+                />
+
+                {/* Data Usage View */}
+                <SettingsItem
+                    icon="data-usage"
+                    title="Data Usage View"
+                    onPress={() => setShowUsageModal(true)}
+                    rightElement={
+                        <TouchableOpacity
+                            style={[styles.dropdownTrigger, { backgroundColor: colors.card, borderColor: colors.border }]}
+                            onPress={() => setShowUsageModal(true)}
+                        >
+                            <Text style={[styles.dropdownText, { color: colors.text }]}>
+                                {usageCardStyle === 'compact' ? 'Compact' : 'Split'}
+                            </Text>
+                            <MaterialIcons name="arrow-drop-down" size={20} color={colors.textSecondary} />
+                        </TouchableOpacity>
+                    }
                 />
 
                 {/* Theme Settings */}
@@ -177,6 +196,22 @@ export default function SettingsIndex() {
                     setShowLanguageModal(false);
                 }}
                 onClose={() => setShowLanguageModal(false)}
+            />
+
+            {/* Usage View Modal */}
+            <SelectionModal
+                visible={showUsageModal}
+                title="Data Usage View"
+                options={[
+                    { label: 'Split View (Default)', value: 'split' },
+                    { label: 'Compact View', value: 'compact' },
+                ]}
+                selectedValue={usageCardStyle}
+                onSelect={(val) => {
+                    setUsageCardStyle(val as 'split' | 'compact');
+                    setShowUsageModal(false);
+                }}
+                onClose={() => setShowUsageModal(false)}
             />
         </ScrollView>
     );

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -1,35 +1,37 @@
 import React from 'react';
-import { View, Text, StyleSheet, ViewStyle, TextStyle } from 'react-native';
+import { View, Text, StyleSheet, ViewStyle, TextStyle, StyleProp } from 'react-native';
 import { BlurView } from 'expo-blur';
 import { useTheme } from '@/theme';
 
 interface CardProps {
   children: React.ReactNode;
-  style?: ViewStyle;
+  style?: StyleProp<ViewStyle>;
   blur?: boolean;
   intensity?: number;
 }
 
-export const Card: React.FC<CardProps> = ({ 
-  children, 
-  style, 
-  blur = false, 
-  intensity = 20 
+export const Card: React.FC<CardProps> = ({
+  children,
+  style,
+  blur = true,
+  intensity = 30
 }) => {
   const { colors, borderRadius, isDark } = useTheme();
 
   if (blur) {
     return (
-      <BlurView 
-        intensity={intensity} 
+      <BlurView
+        intensity={intensity}
         tint={isDark ? 'dark' : 'light'}
+        experimentalBlurMethod='dimezisBlurView' // Better quality on Android if available in version, otherwise ignores
         style={[
           styles.card,
           {
             borderRadius: borderRadius.lg,
             overflow: 'hidden',
             borderWidth: 1,
-            borderColor: colors.border,
+            borderColor: isDark ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.05)',
+            backgroundColor: isDark ? 'rgba(10, 10, 10, 0.4)' : 'rgba(255, 255, 255, 0.4)', // Semi-transparent "Liquid" feel
           },
           style,
         ]}

--- a/src/components/CompactUsageCard.tsx
+++ b/src/components/CompactUsageCard.tsx
@@ -1,0 +1,318 @@
+import React, { useState } from 'react';
+import { View, Text, StyleSheet, TouchableOpacity, ViewStyle, StyleProp } from 'react-native';
+import { MaterialIcons } from '@expo/vector-icons';
+import { useTheme } from '@/theme';
+import { formatDuration } from '@/utils/helpers';
+import { Card } from './Card';
+
+/*
+  Compact Usage Card
+  Displays Session, Monthly, and All Time stats in a single tabbed card.
+*/
+
+interface TrafficStats {
+    currentDownload: number;
+    currentUpload: number;
+    currentConnectTime: number;
+    monthDownload: number;
+    monthUpload: number;
+    monthDuration: number;
+    totalDownload: number;
+    totalUpload: number;
+    totalConnectTime: number;
+}
+
+interface CompactUsageCardProps {
+    stats: TrafficStats;
+    dataLimit?: number; // For monthly progress
+    style?: StyleProp<ViewStyle>;
+}
+
+type TabType = 'session' | 'monthly' | 'total';
+
+// Helper to format bytes
+const formatBytesWithUnit = (bytes: number): { value: string; unit: string } => {
+    if (!bytes || isNaN(bytes) || bytes === 0) return { value: '0', unit: 'B' };
+    const k = 1024;
+    const sizes = ['B', 'KB', 'MB', 'GB', 'TB'];
+    const i = Math.floor(Math.log(bytes) / Math.log(k));
+    return {
+        value: (bytes / Math.pow(k, i)).toFixed(2),
+        unit: sizes[i],
+    };
+};
+
+export function CompactUsageCard({ stats, dataLimit, style }: CompactUsageCardProps) {
+    const { colors, typography, isDark } = useTheme();
+    const [activeTab, setActiveTab] = useState<TabType>('monthly'); // Default to Monthly as in image
+
+    // Highlight Colors
+    const blueColor = '#3b82f6';
+    const greenColor = '#22c55e';
+    const purpleColor = '#a855f7';
+
+    // Get current active stats
+    const getActiveStats = () => {
+        switch (activeTab) {
+            case 'session':
+                return {
+                    download: stats.currentDownload,
+                    upload: stats.currentUpload,
+                    duration: stats.currentConnectTime,
+                    label: 'Current Session'
+                };
+            case 'monthly':
+                return {
+                    download: stats.monthDownload > 0 ? stats.monthDownload : stats.totalDownload, // Fallback logic from home.tsx
+                    upload: stats.monthUpload > 0 ? stats.monthUpload : stats.totalUpload,
+                    duration: stats.monthDuration,
+                    label: 'This Month'
+                };
+            case 'total':
+                return {
+                    download: stats.totalDownload,
+                    upload: stats.totalUpload,
+                    duration: stats.totalConnectTime,
+                    label: 'All Time'
+                };
+        }
+    };
+
+    const currentStats = getActiveStats();
+    const totalBytes = currentStats.download + currentStats.upload;
+    const totalFormatted = formatBytesWithUnit(totalBytes);
+    const dlFormatted = formatBytesWithUnit(currentStats.download);
+    const ulFormatted = formatBytesWithUnit(currentStats.upload);
+
+    // Duration Badge
+    const durationText = currentStats.duration ? formatDuration(currentStats.duration) : '0s';
+
+    // Progress Bar (Only for Monthly with Limit)
+    let percent = 0;
+    let limitFormatted = { value: '0', unit: 'GB' };
+    const showProgress = activeTab === 'monthly' && dataLimit && dataLimit > 0;
+
+    if (showProgress) {
+        percent = Math.min(Math.round((totalBytes / dataLimit) * 100), 100);
+        limitFormatted = formatBytesWithUnit(dataLimit);
+    }
+
+    return (
+        <Card style={[styles.container, style]}>
+            {/* Header: Title + Tabs */}
+            <View style={styles.header}>
+                <Text style={[typography.headline, { color: colors.text, fontWeight: '800', fontSize: 13, letterSpacing: 0.5 }]}>
+                    DATA STATISTICS
+                </Text>
+
+                {/* Tabs */}
+                <View style={[styles.tabsContainer, { backgroundColor: isDark ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.05)' }]}>
+                    {(['session', 'monthly', 'total'] as TabType[]).map((tab) => (
+                        <TouchableOpacity
+                            key={tab}
+                            onPress={() => setActiveTab(tab)}
+                            style={[
+                                styles.tabItem,
+                                activeTab === tab && { backgroundColor: isDark ? 'rgba(59, 130, 246, 0.3)' : 'rgba(59, 130, 246, 0.15)' }
+                            ]}
+                        >
+                            <Text style={[
+                                styles.tabText,
+                                { color: activeTab === tab ? blueColor : colors.textSecondary }
+                            ]}>
+                                {tab === 'total' ? 'All Time' : tab.charAt(0).toUpperCase() + tab.slice(1)}
+                            </Text>
+                        </TouchableOpacity>
+                    ))}
+                </View>
+            </View>
+
+            {/* Main Stats Area */}
+            <View style={styles.mainStatsRow}>
+                {/* Left Side: Usage Value + Duration Badge */}
+                <View style={styles.leftStatsGroup}>
+                    <Text style={[styles.mainValue, { color: blueColor }]}>
+                        {totalFormatted.value}
+                    </Text>
+
+                    <View style={styles.badgeContainer}>
+                        {/* Badge */}
+                        <View style={[styles.durationBadge, { borderColor: colors.border }]}>
+                            <Text style={[typography.caption1, { color: colors.textSecondary, fontSize: 10, fontFamily: 'monospace' }]}>
+                                {durationText}
+                            </Text>
+                        </View>
+                        {/* Label */}
+                        <Text style={[typography.caption1, { color: colors.textSecondary, marginTop: 2 }]}>
+                            {totalFormatted.unit} {currentStats.label}
+                        </Text>
+                    </View>
+                </View>
+
+                {/* Right Side: Progress Info (Monthly Only) */}
+                {showProgress && (
+                    <View style={styles.rightStatsGroup}>
+                        <View style={[styles.percentBadge, { borderColor: blueColor }]}>
+                            <Text style={[typography.caption2, { color: blueColor, fontWeight: 'bold' }]}>
+                                {percent}%
+                            </Text>
+                        </View>
+                        <Text style={[typography.caption2, { color: colors.textSecondary, fontSize: 10, textAlign: 'right', marginTop: 2 }]}>
+                            of {limitFormatted.value} {limitFormatted.unit}
+                        </Text>
+                    </View>
+                )}
+            </View>
+
+            {/* Progress Bar (Full Width if Monthly) */}
+            {showProgress && (
+                <View style={[styles.progressBarTrack, { backgroundColor: isDark ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.05)', marginBottom: 20 }]}>
+                    <View
+                        style={[
+                            styles.progressBarFill,
+                            {
+                                width: `${percent}%`,
+                                backgroundColor: blueColor
+                            }
+                        ]}
+                    />
+                </View>
+            )}
+
+            {/* Spacer if no progress bar to align footer */}
+            {!showProgress && <View style={{ height: 20 }} />}
+
+            {/* Footer Grid */}
+            <View style={styles.footerGrid}>
+                {/* Download */}
+                <View style={[styles.detailCard, { backgroundColor: isDark ? 'rgba(255,255,255,0.05)' : 'rgba(0,0,0,0.03)' }]}>
+                    <View style={[styles.iconCircle, { backgroundColor: 'rgba(34, 197, 94, 0.2)' }]}>
+                        <MaterialIcons name="arrow-downward" size={16} color={greenColor} />
+                    </View>
+                    <View>
+                        <Text style={[styles.detailLabel, { color: colors.textSecondary }]}>DOWNLOAD</Text>
+                        <Text style={[styles.detailValue, { color: colors.text }]}>
+                            {dlFormatted.value} <Text style={{ fontSize: 12, color: colors.textSecondary }}>{dlFormatted.unit}</Text>
+                        </Text>
+                    </View>
+                </View>
+
+                {/* Upload */}
+                <View style={[styles.detailCard, { backgroundColor: isDark ? 'rgba(255,255,255,0.05)' : 'rgba(0,0,0,0.03)' }]}>
+                    <View style={[styles.iconCircle, { backgroundColor: 'rgba(168, 85, 247, 0.2)' }]}>
+                        <MaterialIcons name="arrow-upward" size={16} color={purpleColor} />
+                    </View>
+                    <View>
+                        <Text style={[styles.detailLabel, { color: colors.textSecondary }]}>UPLOAD</Text>
+                        <Text style={[styles.detailValue, { color: colors.text }]}>
+                            {ulFormatted.value} <Text style={{ fontSize: 12, color: colors.textSecondary }}>{ulFormatted.unit}</Text>
+                        </Text>
+                    </View>
+                </View>
+            </View>
+
+        </Card>
+    );
+}
+
+const styles = StyleSheet.create({
+    container: {
+        padding: 20,
+        marginBottom: 16,
+    },
+    header: {
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        marginBottom: 20,
+    },
+    tabsContainer: {
+        flexDirection: 'row',
+        borderRadius: 8,
+        padding: 2,
+        overflow: 'hidden',
+    },
+    tabItem: {
+        paddingHorizontal: 10,
+        paddingVertical: 4,
+        borderRadius: 6,
+    },
+    tabText: {
+        fontSize: 11,
+        fontWeight: '600',
+    },
+    mainStatsRow: {
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        alignItems: 'center', // baseline can be tricky with different fonts, center often looks cleaner for side-by-side
+        marginBottom: 10,
+    },
+    leftStatsGroup: {
+        flexDirection: 'row',
+        alignItems: 'center',
+    },
+    badgeContainer: {
+        alignItems: 'flex-start',
+        marginLeft: 12,
+    },
+    rightStatsGroup: {
+        alignItems: 'flex-end',
+    },
+    mainValue: {
+        fontSize: 42,
+        fontWeight: 'bold',
+        letterSpacing: -1,
+        lineHeight: 42,
+    },
+    durationBadge: {
+        borderWidth: 1,
+        borderRadius: 6,
+        paddingHorizontal: 6,
+        paddingVertical: 2,
+    },
+    percentBadge: {
+        borderWidth: 1,
+        borderRadius: 10,
+        paddingHorizontal: 6,
+        paddingVertical: 1,
+    },
+    progressBarTrack: {
+        height: 8,
+        borderRadius: 4,
+        overflow: 'hidden',
+        marginTop: 8,
+    },
+    progressBarFill: {
+        height: '100%',
+        borderRadius: 4,
+    },
+    footerGrid: {
+        flexDirection: 'row',
+        gap: 12,
+    },
+    detailCard: {
+        flex: 1,
+        flexDirection: 'row',
+        alignItems: 'center',
+        padding: 12,
+        borderRadius: 12,
+        gap: 12,
+    },
+    iconCircle: {
+        width: 32,
+        height: 32,
+        borderRadius: 16,
+        justifyContent: 'center',
+        alignItems: 'center',
+    },
+    detailLabel: {
+        fontSize: 10,
+        fontWeight: '600',
+        letterSpacing: 0.5,
+        marginBottom: 2,
+    },
+    detailValue: {
+        fontSize: 16,
+        fontWeight: '700',
+    },
+});

--- a/src/components/PageSheetModal.tsx
+++ b/src/components/PageSheetModal.tsx
@@ -10,6 +10,7 @@ import {
     ActivityIndicator,
 } from 'react-native';
 import { useTheme } from '@/theme';
+import { BlurView } from 'expo-blur';
 
 interface PageSheetModalProps {
     visible: boolean;
@@ -32,16 +33,25 @@ export function PageSheetModal({
     cancelText = 'Cancel',
     children,
 }: PageSheetModalProps) {
-    const { colors, typography } = useTheme();
+    const { colors, typography, isDark } = useTheme();
 
     return (
         <Modal
             visible={visible}
             animationType="slide"
-            presentationStyle="pageSheet"
+            presentationStyle="overFullScreen"
+            transparent
             onRequestClose={onClose}
         >
-            <View style={[styles.container, { backgroundColor: colors.background }]}>
+            <BlurView
+                intensity={50} // Higher intensity for full screen sheet
+                tint={isDark ? 'dark' : 'light'}
+                experimentalBlurMethod='dimezisBlurView'
+                style={[
+                    styles.container,
+                    { backgroundColor: isDark ? 'rgba(10, 10, 10, 0.6)' : 'rgba(255, 255, 255, 0.6)' }
+                ]}
+            >
                 <View style={[styles.header, {
                     borderBottomColor: colors.border,
                     paddingTop: Platform.OS === 'android' ? (StatusBar.currentHeight || 24) + 16 : 16
@@ -65,7 +75,7 @@ export function PageSheetModal({
                     )}
                 </View>
                 {children}
-            </View>
+            </BlurView>
         </Modal>
     );
 }

--- a/src/components/SelectionModal.tsx
+++ b/src/components/SelectionModal.tsx
@@ -8,8 +8,11 @@ import {
     ScrollView,
 } from 'react-native';
 import { MaterialIcons } from '@expo/vector-icons';
+import { BlurView } from 'expo-blur';
 import { useTheme } from '@/theme';
 import { useTranslation } from '@/i18n';
+
+// ... (keep interface SelectionOption)
 
 export interface SelectionOption {
     label: string;
@@ -33,7 +36,7 @@ export function SelectionModal({
     onSelect,
     onClose,
 }: SelectionModalProps) {
-    const { colors, typography } = useTheme();
+    const { colors, typography, isDark } = useTheme();
     const { t } = useTranslation();
 
     return (
@@ -44,7 +47,19 @@ export function SelectionModal({
             onRequestClose={onClose}
         >
             <View style={styles.modalOverlay}>
-                <View style={[styles.modalContent, { backgroundColor: colors.card, borderColor: colors.border }]}>
+                <BlurView
+                    intensity={30}
+                    tint={isDark ? 'dark' : 'light'}
+                    experimentalBlurMethod='dimezisBlurView'
+                    style={[
+                        styles.modalContent,
+                        {
+                            backgroundColor: isDark ? 'rgba(10, 10, 10, 0.8)' : 'rgba(255, 255, 255, 0.8)',
+                            borderColor: isDark ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.05)',
+                            borderWidth: 1,
+                        }
+                    ]}
+                >
                     <View style={styles.modalHeader}>
                         <Text style={[styles.modalTitle, { color: colors.text }]}>{title}</Text>
                     </View>
@@ -94,7 +109,7 @@ export function SelectionModal({
                             <Text style={styles.buttonText}>{t('common.cancel')}</Text>
                         </TouchableOpacity>
                     </View>
-                </View>
+                </BlurView>
             </View>
         </Modal>
     );

--- a/src/components/ThemedAlert.tsx
+++ b/src/components/ThemedAlert.tsx
@@ -7,6 +7,7 @@ import {
     StyleSheet,
     Dimensions,
 } from 'react-native';
+import { BlurView } from 'expo-blur';
 import { useTheme } from '@/theme';
 
 interface AlertButton {
@@ -30,7 +31,7 @@ export const ThemedAlert: React.FC<ThemedAlertProps> = ({
     buttons = [{ text: 'OK' }],
     onDismiss,
 }) => {
-    const { colors, typography } = useTheme();
+    const { colors, typography, isDark } = useTheme();
 
     const handleButtonPress = (button: AlertButton) => {
         button.onPress?.();
@@ -56,8 +57,28 @@ export const ThemedAlert: React.FC<ThemedAlertProps> = ({
             onRequestClose={onDismiss}
         >
             <View style={styles.overlay}>
-                <View style={[styles.alertContainer, { backgroundColor: colors.card }]}>
-                    <Text style={[typography.headline, styles.title, { color: colors.text }]}>
+                <BlurView
+                    intensity={30}
+                    tint={isDark ? 'dark' : 'light'}
+                    experimentalBlurMethod='dimezisBlurView'
+                    style={[
+                        styles.alertContainer,
+                        {
+                            backgroundColor: isDark ? 'rgba(10, 10, 10, 0.92)' : 'rgba(255, 255, 255, 0.92)',
+                            borderColor: isDark ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.05)',
+                            borderWidth: 1,
+                        }
+                    ]}
+                >
+                    <Text style={[
+                        typography.headline,
+                        styles.title,
+                        {
+                            color: colors.text,
+                            textShadowColor: 'transparent',
+                            textShadowRadius: 0
+                        }
+                    ]}>
                         {title}
                     </Text>
 
@@ -90,7 +111,7 @@ export const ThemedAlert: React.FC<ThemedAlertProps> = ({
                             </TouchableOpacity>
                         ))}
                     </View>
-                </View>
+                </BlurView>
             </View>
         </Modal>
     );

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -11,6 +11,7 @@ export * from './WebViewLogin';
 export * from './ThemedAlert';
 export * from './PageSheetModal';
 export * from './BandSelectionModal';
+export * from './CompactUsageCard';
 export * from './UsageCard';
 export * from './SignalCard';
 export * from './MonthlySettingsModal';

--- a/src/stores/theme.store.ts
+++ b/src/stores/theme.store.ts
@@ -12,6 +12,8 @@ interface ThemeState {
   isLanguageInitialized: boolean; // Track if language was auto-detected
 
   setThemeMode: (mode: ThemeMode) => void;
+  usageCardStyle: 'split' | 'compact';
+  setUsageCardStyle: (style: 'split' | 'compact') => void;
   setRefreshInterval: (interval: number) => void;
   setLanguage: (language: string) => void;
   initializeLanguage: () => void; // Auto-detect device language on first install
@@ -28,6 +30,8 @@ export const useThemeStore = create<ThemeState>()(
       setThemeMode: (mode) => {
         set({ themeMode: mode });
       },
+      usageCardStyle: 'split',
+      setUsageCardStyle: (style) => set({ usageCardStyle: style }),
       setRefreshInterval: (interval) => set({ refreshInterval: interval }),
       setLanguage: (language) => set({ language }),
 


### PR DESCRIPTION
- Added [CompactUsageCard](cci:1://file:///home/son/Projects/hm-mobile/src/components/CompactUsageCard.tsx:44:0-215:1) component with tabbed stats (Session/Monthly/Total).
- Added `usageCardStyle` to `ThemeStore` ('split' | 'compact').
- Implemented conditional rendering in [HomeScreen](cci:1://file:///home/son/Projects/hm-mobile/src/app/%28tabs%29/home.tsx:58:0-1144:1) for usage cards.
- Added "Data Usage View" setting in Main Settings (General) with `SelectionModal`.
- Refined [CompactUsageCard](cci:1://file:///home/son/Projects/hm-mobile/src/components/CompactUsageCard.tsx:44:0-215:1) layout:
  - Aligned usage value and duration badge to the left.
  - Aligned monthly quota percentage to the right.
  - Removed styling underline.
- Updated `SettingsIndex` to include the new setting.