### PR TITLE
feat(ads): implement interstitial and banner ads with secure CI/CD builds

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -19,6 +19,12 @@ on:
           - latest
           - pre-release
 
+env:
+  ADMOB_ANDROID_APP_ID: ${{ secrets.ADMOB_ANDROID_APP_ID }}
+  ADMOB_BANNER_UNIT_ID: ${{ secrets.ADMOB_BANNER_UNIT_ID }}
+  ADMOB_INTERSTITIAL_UNIT_ID: ${{ secrets.ADMOB_INTERSTITIAL_UNIT_ID }}
+  ADMOB_REWARDED_UNIT_ID: ${{ secrets.ADMOB_REWARDED_UNIT_ID }}
+
 jobs:
   build-arm64:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -24,6 +24,12 @@ on:
         default: false
         type: boolean
 
+env:
+  ADMOB_ANDROID_APP_ID: ${{ secrets.ADMOB_ANDROID_APP_ID }}
+  ADMOB_BANNER_UNIT_ID: ${{ secrets.ADMOB_BANNER_UNIT_ID }}
+  ADMOB_INTERSTITIAL_UNIT_ID: ${{ secrets.ADMOB_INTERSTITIAL_UNIT_ID }}
+  ADMOB_REWARDED_UNIT_ID: ${{ secrets.ADMOB_REWARDED_UNIT_ID }}
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ yarn-error.*
 *.pem
 
 # local env files
+.env
 .env*.local
 
 # typescript

--- a/app.config.ts
+++ b/app.config.ts
@@ -1,5 +1,7 @@
 import type { ConfigContext, ExpoConfig } from 'expo/config';
 import type { WithAndroidWidgetsParams } from 'react-native-android-widget';
+import { withGradleProperties } from '@expo/config-plugins';
+import fs from 'fs';
 
 const widgetConfig: WithAndroidWidgetsParams = {
     widgets: [
@@ -20,53 +22,91 @@ const widgetConfig: WithAndroidWidgetsParams = {
     ],
 };
 
-export default ({ config }: ConfigContext): ExpoConfig => ({
-    ...config,
-    name: 'Huawei Manager',
-    slug: 'hm-mobile',
-    version: '1.1.25',
-    orientation: 'portrait',
-    icon: './assets/logo.png',
-    userInterfaceStyle: 'automatic',
-    scheme: 'hm-mobile',
-    plugins: [
-        'expo-router',
-        [
-            'expo-build-properties',
-            {
-                android: {
-                    usesCleartextTraffic: true,
+const isDev = process.env.APP_ENV === 'development';
+
+const getJavaHome = () => {
+    if (process.env.JAVA_HOME) {
+        return process.env.JAVA_HOME;
+    }
+    const linuxPath = '/usr/lib/jvm/java-21-openjdk-amd64';
+    if (fs.existsSync(linuxPath)) {
+        return linuxPath;
+    }
+    return undefined;
+};
+
+export default ({ config }: ConfigContext): ExpoConfig => {
+    const expoConfig: ExpoConfig = {
+        ...config,
+        name: isDev ? 'HM Mobile [DEV]' : 'Huawei Manager',
+        slug: 'hm-mobile',
+        version: '1.1.26',
+        orientation: 'portrait',
+        icon: './assets/logo.png',
+        userInterfaceStyle: 'automatic',
+        scheme: 'hm-mobile',
+        plugins: [
+            'expo-router',
+            [
+                'expo-build-properties',
+                {
+                    android: {
+                        usesCleartextTraffic: true,
+                    },
                 },
-            },
+            ],
+            'expo-localization',
+            'expo-font',
+            ['react-native-android-widget', widgetConfig],
+            'expo-mail-composer',
+            [
+                'react-native-google-mobile-ads',
+                {
+                    androidAppId: process.env.ADMOB_ANDROID_APP_ID || 'ca-app-pub-3940256099942544~3347511713',
+                },
+            ],
         ],
-        'expo-localization',
-        'expo-font',
-        ['react-native-android-widget', widgetConfig],
-        'expo-mail-composer',
-    ],
-    splash: {
-        image: './assets/logo.png',
-        resizeMode: 'contain',
-        backgroundColor: '#ffffff',
-    },
-    ios: {
-        supportsTablet: true,
-    },
-    android: {
-        adaptiveIcon: {
-            foregroundImage: './assets/logo.png',
+        splash: {
+            image: './assets/logo.png',
+            resizeMode: 'contain',
             backgroundColor: '#ffffff',
         },
-        predictiveBackGestureEnabled: false,
-        package: 'com.alrescha79.hmmobile',
-        googleServicesFile: './google-services.json',
-    },
-    web: {
-        favicon: './assets/logo.png',
-    },
-    extra: {
-        eas: {
-            projectId: '930db156-f012-4b37-809c-d023a044d3b3',
+        ios: {
+            supportsTablet: true,
         },
-    },
-});
+        android: {
+            adaptiveIcon: {
+                foregroundImage: './assets/logo.png',
+                backgroundColor: '#ffffff',
+            },
+            predictiveBackGestureEnabled: false,
+            package: isDev ? 'com.alrescha79.hmmobile.dev' : 'com.alrescha79.hmmobile',
+            googleServicesFile: './google-services.json',
+        },
+        web: {
+            favicon: './assets/logo.png',
+        },
+        extra: {
+            eas: {
+                projectId: '930db156-f012-4b37-809c-d023a044d3b3',
+            },
+            admobBannerUnitId: process.env.ADMOB_BANNER_UNIT_ID || '',
+            admobInterstitialUnitId: process.env.ADMOB_INTERSTITIAL_UNIT_ID || '',
+            admobRewardedUnitId: process.env.ADMOB_REWARDED_UNIT_ID || '',
+        },
+    };
+
+    const javaHome = getJavaHome();
+    if (!javaHome) {
+        return expoConfig;
+    }
+
+    return withGradleProperties(expoConfig, (cfg) => {
+        cfg.modResults.push({
+            type: 'property',
+            key: 'org.gradle.java.home',
+            value: javaHome,
+        });
+        return cfg;
+    });
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hm-mobile",
-  "version": "1.1.10",
+  "version": "1.1.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hm-mobile",
-      "version": "1.1.10",
+      "version": "1.1.25",
       "dependencies": {
         "@expo-google-fonts/doto": "^0.4.1",
         "@react-native-async-storage/async-storage": "^2.2.0",
@@ -40,6 +40,7 @@
         "react-native": "0.81.5",
         "react-native-android-widget": "^0.17.2",
         "react-native-gesture-handler": "~2.28.0",
+        "react-native-google-mobile-ads": "^16.0.3",
         "react-native-keyboard-controller": "^1.20.4",
         "react-native-reanimated": "~4.1.1",
         "react-native-safe-area-context": "~5.6.0",
@@ -2978,6 +2979,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/@iabtcf/core": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@iabtcf/core/-/core-1.5.6.tgz",
+      "integrity": "sha512-u2q9thI9vLurYZdGtyJsDYOqoeLc4EgQsYGSc+UVibYII61B/ENJPZS6eFlML1F0hSoTR/goptpo5nGRDkKd2w==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@ide/backoff": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@ide/backoff/-/backoff-1.0.0.tgz",
@@ -5601,6 +5608,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/destroy": {
@@ -9930,6 +9946,24 @@
         "react-native": "*"
       }
     },
+    "node_modules/react-native-google-mobile-ads": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/react-native-google-mobile-ads/-/react-native-google-mobile-ads-16.0.3.tgz",
+      "integrity": "sha512-H+ViSEPiwAorLhKL29t6oaEN+thA1KTvSR8IYRY80Bv4Y62IdIYcucuqUsELrH2qFPC3+D2uPRG4HriLY/hjvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@iabtcf/core": "^1.5.6",
+        "use-deep-compare-effect": "^1.8.1"
+      },
+      "peerDependencies": {
+        "expo": ">=47.0.0"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-native-is-edge-to-edge": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.2.1.tgz",
@@ -11514,6 +11548,23 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/use-deep-compare-effect": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/use-deep-compare-effect/-/use-deep-compare-effect-1.8.1.tgz",
+      "integrity": "sha512-kbeNVZ9Zkc0RFGpfMN3MNfaKNvcLNyxOAAd9O4CBZ+kCBXXscn9s/4I+8ytUER4RDpEYs5+O6Rs4PqiZ+rHr5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "dequal": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "react": ">=16.13"
       }
     },
     "node_modules/use-latest-callback": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hm-mobile",
-  "version": "1.1.25",
+  "version": "1.1.26",
   "main": "index.js",
   "scripts": {
     "start": "expo start",
@@ -9,13 +9,12 @@
     "start:lan": "expo start --lan",
     "start:localhost": "expo start --localhost",
     "dev": "expo start --lan --clear",
-    "android": "expo run:android",
+    "android": "APP_ENV=development npx expo run:android",
+    "prebuild": "APP_ENV=development npx expo prebuild --platform android --clean",
     "android:tunnel": "expo start --android --tunnel",
     "ios": "expo run:ios",
     "web": "expo start --web",
-    "setup": "bash setup-dev.sh",
-    "fix": "bash fix-expo.sh",
-    "build:android": "expo prebuild --platform android && cd android && ./gradlew assembleRelease"
+    "build:android": "APP_ENV=production expo prebuild --platform android && cd android && ./gradlew assembleRelease"
   },
   "dependencies": {
     "@expo-google-fonts/doto": "^0.4.1",
@@ -50,6 +49,7 @@
     "react-native": "0.81.5",
     "react-native-android-widget": "^0.17.2",
     "react-native-gesture-handler": "~2.28.0",
+    "react-native-google-mobile-ads": "^16.0.3",
     "react-native-keyboard-controller": "^1.20.4",
     "react-native-reanimated": "~4.1.1",
     "react-native-safe-area-context": "~5.6.0",

--- a/src/app/(tabs)/home.tsx
+++ b/src/app/(tabs)/home.tsx
@@ -12,7 +12,7 @@ import { useRouter } from 'expo-router';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { MaterialIcons } from '@expo/vector-icons';
 import { useTheme } from '@/theme';
-import { Card, ThemedAlertHelper, WebViewLogin, BandSelectionModal, getSelectedBandsDisplay, MonthlySettingsModal, DiagnosisResultModal, SpeedtestModal, MeshGradientBackground, AnimatedScreen, BouncingDots, ModernRefreshIndicator, CustomRefreshScrollView, SignalPointingModal } from '@/components';
+import { Card, ThemedAlertHelper, WebViewLogin, BandSelectionModal, getSelectedBandsDisplay, MonthlySettingsModal, DiagnosisResultModal, SpeedtestModal, MeshGradientBackground, AnimatedScreen, BouncingDots, ModernRefreshIndicator, CustomRefreshScrollView, SignalPointingModal, AdBanner } from '@/components';
 import { QuickActionsCard, ConnectionStatusCard, NoDataWarningCard, SignalInfoCard, TrafficStatsCard, ConnectionStatusSkeleton, QuickActionsSkeleton, TrafficStatsSkeleton, homeStyles as styles } from '@/components/home';
 import { useAuthStore } from '@/stores/auth.store';
 import { useModemStore } from '@/stores/modem.store';
@@ -26,6 +26,7 @@ import { useSMSStore } from '@/stores/sms.store';
 import { useWiFiStore } from '@/stores/wifi.store';
 import { SMSService } from '@/services/sms.service';
 import { WiFiService } from '@/services/wifi.service';
+import { showInterstitial, showRewarded } from '@/services/ad.service';
 
 export default function HomeScreen() {
   const router = useRouter();
@@ -441,6 +442,7 @@ export default function HomeScreen() {
         const dataStatus = await modemService.getMobileDataStatus();
         setMobileDataStatus(dataStatus);
         ThemedAlertHelper.alert(t('common.success'), newState ? t('home.dataEnabled') : t('home.dataDisabled'));
+        showInterstitial(() => { });
       } catch (error) {
         console.error('Error toggling mobile data:', error);
         ThemedAlertHelper.alert(t('common.error'), t('alerts.failedToggleData'));
@@ -481,6 +483,7 @@ export default function HomeScreen() {
               t('alerts.ipChangeStartedMessage'),
               [{ text: t('common.ok') }]
             );
+            showInterstitial(() => { });
 
             modemService.triggerPlmnScan().catch((error) => {
             });
@@ -561,6 +564,7 @@ export default function HomeScreen() {
       ]);
       setDiagnosisSummary(t(`home.${result.summaryKey}`));
       setShowDiagnosisModal(true);
+      showInterstitial(() => { });
     } catch (error: any) {
       console.error('Error running one click check:', error);
       if (error?.message?.includes('Network Error') || error?.code === 'ERR_NETWORK') {
@@ -756,6 +760,8 @@ export default function HomeScreen() {
             />
           )}
 
+          <AdBanner />
+
           <QuickActionsCard
             t={t}
             selectedBands={selectedBands}
@@ -777,6 +783,8 @@ export default function HomeScreen() {
             signalInfo={signalInfo}
             modemStatus={modemStatus}
           />
+
+          <AdBanner />
 
           {trafficStats && (
             <TrafficStatsCard
@@ -821,6 +829,7 @@ export default function HomeScreen() {
             modemService={modemService}
             onSaved={() => {
               if (modemService) loadBands(modemService);
+              showInterstitial(() => { });
             }}
           />
 

--- a/src/app/(tabs)/settings/index.tsx
+++ b/src/app/(tabs)/settings/index.tsx
@@ -13,9 +13,10 @@ import Constants from 'expo-constants';
 import { MaterialIcons } from '@expo/vector-icons';
 import { useTheme } from '@/theme';
 import { useTranslation } from '@/i18n';
-import { SettingsSection, SettingsItem, SelectionModal, MeshGradientBackground, PageHeader, AnimatedScreen, ThemedSwitch, ThemedAlertHelper, BouncingDots } from '@/components';
+import { SettingsSection, SettingsItem, SelectionModal, MeshGradientBackground, PageHeader, AnimatedScreen, ThemedSwitch, ThemedAlertHelper, BouncingDots, AdBanner } from '@/components';
 import { useThemeStore } from '@/stores/theme.store';
 import { useDebugStore } from '@/stores/debug.store';
+import { showInterstitial } from '@/services/ad.service';
 
 export default function SettingsIndex() {
     const router = useRouter();
@@ -71,6 +72,7 @@ export default function SettingsIndex() {
                             subtitle={t('settings.mobileNetworkSubtitle') || 'Data, Roaming, Bands'}
                             onPress={() => router.push('/settings/mobile-network')}
                         />
+                        <AdBanner />
                         <SettingsItem
                             icon="settings-ethernet"
                             title={t('settings.lanSettings')}
@@ -104,6 +106,8 @@ export default function SettingsIndex() {
                                 </TouchableOpacity>
                             }
                         />
+
+                        <AdBanner />
 
                         <SettingsItem
                             icon="brightness-6"
@@ -160,6 +164,7 @@ export default function SettingsIndex() {
                             subtitle="github.com/alrescha79-cmd"
                             onPress={handleOpenGitHub}
                         />
+                        <AdBanner />
                         <SettingsItem
                             icon="bug-report"
                             title={t('settings.bugReport')}
@@ -316,8 +321,12 @@ export default function SettingsIndex() {
                         ]}
                         selectedValue={themeMode}
                         onSelect={(val) => {
+                            const changed = val !== themeMode;
                             setThemeMode(val);
                             setShowThemeModal(false);
+                            if (changed) {
+                                showInterstitial(() => {});
+                            }
                         }}
                         onClose={() => setShowThemeModal(false)}
                     />
@@ -331,8 +340,12 @@ export default function SettingsIndex() {
                         ]}
                         selectedValue={language}
                         onSelect={(val) => {
+                            const changed = val !== language;
                             setLanguage(val);
                             setShowLanguageModal(false);
+                            if (changed) {
+                                showInterstitial(() => {});
+                            }
                         }}
                         onClose={() => setShowLanguageModal(false)}
                     />
@@ -346,8 +359,12 @@ export default function SettingsIndex() {
                         ]}
                         selectedValue={usageCardStyle}
                         onSelect={(val) => {
+                            const changed = val !== usageCardStyle;
                             setUsageCardStyle(val as 'split' | 'compact');
                             setShowUsageModal(false);
+                            if (changed) {
+                                showInterstitial(() => {});
+                            }
                         }}
                         onClose={() => setShowUsageModal(false)}
                     />

--- a/src/app/(tabs)/settings/lan.tsx
+++ b/src/app/(tabs)/settings/lan.tsx
@@ -19,7 +19,8 @@ import { useTheme } from '@/theme';
 import { useAuthStore } from '@/stores/auth.store';
 import { NetworkSettingsService } from '@/services/network.settings.service';
 import { useTranslation } from '@/i18n';
-import { ThemedAlertHelper, Button, InfoRow, SettingsSection, SettingsItem, SelectionModal, MeshGradientBackground, PageHeader, ThemedSwitch, BouncingDots, AnimatedScreen } from '@/components';
+import { ThemedAlertHelper, Button, InfoRow, SettingsSection, SettingsItem, SelectionModal, MeshGradientBackground, PageHeader, ThemedSwitch, BouncingDots, AnimatedScreen, AdBanner } from '@/components';
+import { showInterstitial } from '@/services/ad.service';
 
 const ETHERNET_MODES = [
     { value: 'auto', labelKey: 'networkSettings.modeAuto' },
@@ -122,6 +123,9 @@ export default function LanSettingsScreen() {
     // Ethernet Logic
     const handleEthernetModeChange = async (mode: typeof ethernetMode) => {
         if (!networkSettingsService || isChangingEthernet) return;
+
+        const changed = mode !== ethernetMode;
+
         setIsChangingEthernet(true);
         try {
             await networkSettingsService.setEthernetConnectionMode(mode);
@@ -129,6 +133,9 @@ export default function LanSettingsScreen() {
             const settings = await networkSettingsService.getEthernetSettings();
             setEthernetStatus(settings.status);
             ThemedAlertHelper.alert(t('common.success'), t('networkSettings.profileSaved'));
+            if (changed) {
+                showInterstitial(() => {});
+            }
         } catch (error) {
             ThemedAlertHelper.alert(t('common.error'), t('common.error'));
         } finally {
@@ -446,6 +453,8 @@ export default function LanSettingsScreen() {
                         )}
                     </SettingsSection>
 
+                    <AdBanner />
+
                     <SettingsSection title={t('networkSettings.apnProfiles')}>
 
                         {apnProfiles.map((profile, index) => (
@@ -539,6 +548,8 @@ export default function LanSettingsScreen() {
                                             onChangeText={setApnApn}
                                         />
                                     </View>
+
+                                    <AdBanner />
 
                                     {/* Username */}
                                     <View style={{ marginBottom: 16 }}>

--- a/src/app/(tabs)/settings/mobile-network.tsx
+++ b/src/app/(tabs)/settings/mobile-network.tsx
@@ -12,8 +12,9 @@ import { useTheme } from '@/theme';
 import { useAuthStore } from '@/stores/auth.store';
 import { ModemService } from '@/services/modem.service';
 import { useTranslation } from '@/i18n';
-import { BandSelectionModal, ThemedAlertHelper, getSelectedBandsDisplay, SettingsSection, SettingsItem, MonthlySettingsModal, SelectionModal, MeshGradientBackground, PageHeader, ThemedSwitch, BouncingDots, AnimatedScreen, SignalPointingModal } from '@/components';
+import { BandSelectionModal, ThemedAlertHelper, getSelectedBandsDisplay, SettingsSection, SettingsItem, MonthlySettingsModal, SelectionModal, MeshGradientBackground, PageHeader, ThemedSwitch, BouncingDots, AnimatedScreen, SignalPointingModal, AdBanner } from '@/components';
 import { MaterialIcons } from '@expo/vector-icons';
+import { showInterstitial } from '@/services/ad.service';
 
 const NETWORK_MODES = [
     { value: '00', labelKey: 'settings.networkAuto' },
@@ -173,12 +174,18 @@ export default function MobileNetworkSettingsScreen() {
 
     const handleNetworkModeChange = async (mode: string) => {
         if (!modemService) return;
+
+        const changed = mode !== networkMode;
+
         setShowNetworkModeModal(false); // Close first
         setIsChangingNetwork(true);
         try {
             await modemService.setNetworkMode(mode);
             setNetworkMode(mode);
             ThemedAlertHelper.alert(t('common.success'), t('settings.networkModeChanged'));
+            if (changed) {
+                showInterstitial(() => {});
+            }
         } catch (error) {
             ThemedAlertHelper.alert(t('common.error'), t('alerts.failedChangeNetwork'));
         } finally {
@@ -245,6 +252,8 @@ export default function MobileNetworkSettingsScreen() {
                         />
                     </SettingsSection>
 
+                    <AdBanner />
+
                     <SettingsSection title={t('settings.preferredNetwork')}>
                         <SettingsItem
                             title={t('settings.preferredNetwork')}
@@ -263,6 +272,8 @@ export default function MobileNetworkSettingsScreen() {
                             isLast
                         />
                     </SettingsSection>
+
+                    <AdBanner />
 
                     {/* Monthly Usage Settings */}
                     <SettingsSection title={t('home.monthlySettings')}>

--- a/src/app/(tabs)/settings/modem.tsx
+++ b/src/app/(tabs)/settings/modem.tsx
@@ -10,8 +10,9 @@ import { useAuthStore } from '@/stores/auth.store';
 import { useModemStore } from '@/stores/modem.store';
 import { ModemService } from '@/services/modem.service';
 import { useTranslation } from '@/i18n';
-import { ThemedAlertHelper, SettingsSection, SettingsItem, SelectionModal, MeshGradientBackground, PageHeader, BouncingDots, AnimatedScreen } from '@/components';
+import { ThemedAlertHelper, SettingsSection, SettingsItem, SelectionModal, MeshGradientBackground, PageHeader, BouncingDots, AnimatedScreen, AdBanner } from '@/components';
 import { MaterialIcons } from '@expo/vector-icons';
+import { showInterstitial } from '@/services/ad.service';
 
 const ANTENNA_MODES = [
     { value: 'auto', labelKey: 'settings.antennaAuto', icon: 'settings-input-antenna' as const },
@@ -81,11 +82,16 @@ export default function ModemSettingsScreen() {
     const handleAntennaChange = async (mode: 'auto' | 'internal' | 'external') => {
         if (!modemService || isChangingAntenna) return;
 
+        const changed = mode !== antennaMode;
+
         setIsChangingAntenna(true);
         try {
             await modemService.setAntennaMode(mode);
             setAntennaMode(mode);
             ThemedAlertHelper.alert(t('common.success'), t('settings.antennaModeChanged'));
+            if (changed) {
+                showInterstitial(() => {});
+            }
         } catch (error) {
             ThemedAlertHelper.alert(t('common.error'), t('alerts.failedChangeAntenna'));
         } finally {
@@ -120,6 +126,8 @@ export default function ModemSettingsScreen() {
                             </>
                         )}
                     </SettingsSection>
+
+                    <AdBanner />
 
                     <SettingsSection title={t('settings.antennaSettings')}>
                         <SettingsItem

--- a/src/app/(tabs)/settings/notifications.tsx
+++ b/src/app/(tabs)/settings/notifications.tsx
@@ -14,7 +14,7 @@ import { useTheme } from '@/theme';
 import { useTranslation } from '@/i18n';
 import { useModemStore } from '@/stores/modem.store';
 import { useThemeStore } from '@/stores/theme.store';
-import { MeshGradientBackground, AnimatedScreen, ThemedAlertHelper, ThemedSwitch } from '@/components';
+import { MeshGradientBackground, AnimatedScreen, ThemedAlertHelper, ThemedSwitch, AdBanner } from '@/components';
 import {
     getNotificationSettings,
     saveNotificationSettings,
@@ -125,6 +125,8 @@ export default function NotificationSettingsScreen() {
                             />
                         </View>
 
+                        <AdBanner />
+
                         {/* Monthly Usage */}
                         <View style={styles.settingRow}>
                             <View style={styles.settingInfo}>
@@ -193,6 +195,8 @@ export default function NotificationSettingsScreen() {
                                 onValueChange={(v) => updateSetting('smsEnabled', v)}
                             />
                         </View>
+
+                        <AdBanner />
 
                         {/* Tab Badges */}
                         <View style={[styles.settingRow, { borderBottomColor: colors.border }]}>

--- a/src/app/(tabs)/settings/system.tsx
+++ b/src/app/(tabs)/settings/system.tsx
@@ -16,7 +16,7 @@ import { useAuthStore } from '@/stores/auth.store';
 import { useThemeStore } from '@/stores/theme.store';
 import { ModemService } from '@/services/modem.service';
 import { useTranslation } from '@/i18n';
-import { ThemedAlertHelper, Button, SettingsSection, SettingsItem, MeshGradientBackground, PageHeader, ThemedSwitch, BouncingDots, AnimatedScreen } from '@/components';
+import { ThemedAlertHelper, Button, SettingsSection, SettingsItem, MeshGradientBackground, PageHeader, ThemedSwitch, BouncingDots, AnimatedScreen, AdBanner } from '@/components';
 
 const TIMEZONES = [
     'UTC-12', 'UTC-11', 'UTC-10', 'UTC-9', 'UTC-8', 'UTC-7', 'UTC-6', 'UTC-5',
@@ -263,6 +263,8 @@ export default function SystemSettingsScreen() {
                             isLast
                         />
                     </SettingsSection>
+
+                    <AdBanner />
 
                     {/* Connection Credentials */}
                     <SettingsSection title={t('settings.modemControl')}>

--- a/src/app/(tabs)/sms.tsx
+++ b/src/app/(tabs)/sms.tsx
@@ -15,7 +15,7 @@ import { MaterialIcons } from '@expo/vector-icons';
 import dayjs from 'dayjs';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTheme } from '@/theme';
-import { Card, CardHeader, Input, Button, ThemedAlertHelper, MeshGradientBackground, AnimatedScreen, BouncingDots, ModernRefreshIndicator, KeyboardAnimatedView } from '@/components';
+import { Card, CardHeader, Input, Button, ThemedAlertHelper, MeshGradientBackground, AnimatedScreen, BouncingDots, ModernRefreshIndicator, KeyboardAnimatedView, AdBanner } from '@/components';
 import { SMSListItem, SMSStatsCard, SMSDetailModal, SMSStatsSkeleton, SMSListSkeleton, SMSSearchSkeleton, smsStyles as styles, SMSFilterType } from '@/components/sms';
 import { formatTimeAgo } from '@/utils/formatters';
 import { useAuthStore } from '@/stores/auth.store';
@@ -538,16 +538,20 @@ export default function SMSScreen() {
             )}
 
             {!smsSupported || filteredMessages.length === 0 ? (
-              <View style={[styles.emptyState, {
-                backgroundColor: isDark ? glassmorphism.background.dark.card : glassmorphism.background.light.card,
-                borderWidth: 1,
-                borderColor: isDark ? glassmorphism.border.dark : glassmorphism.border.light,
-              }]}>
-                <MaterialIcons name="sms" size={48} color={colors.textSecondary} style={{ opacity: 0.5 }} />
-                <Text style={[typography.body, { color: colors.textSecondary, textAlign: 'center', marginTop: spacing.md }]}>
-                  {isRefreshing ? t('sms.loadingMessages') : searchQuery ? t('sms.noSearchResults') : `${t('sms.noMessages')}\n${t('sms.smsNotSupported')}`}
-                </Text>
-              </View>
+              <>
+                <AdBanner />
+                <View style={[styles.emptyState, {
+                  backgroundColor: isDark ? glassmorphism.background.dark.card : glassmorphism.background.light.card,
+                  borderWidth: 1,
+                  borderColor: isDark ? glassmorphism.border.dark : glassmorphism.border.light,
+                }]}>
+                  <MaterialIcons name="sms" size={48} color={colors.textSecondary} style={{ opacity: 0.5 }} />
+                  <Text style={[typography.body, { color: colors.textSecondary, textAlign: 'center', marginTop: spacing.md }]}>
+                    {isRefreshing ? t('sms.loadingMessages') : searchQuery ? t('sms.noSearchResults') : `${t('sms.noMessages')}\n${t('sms.smsNotSupported')}`}
+                  </Text>
+                </View>
+                <AdBanner />
+              </>
             ) : (
               <View style={[styles.messagesList, {
                 backgroundColor: isDark ? glassmorphism.background.dark.card : glassmorphism.background.light.card,
@@ -555,17 +559,21 @@ export default function SMSScreen() {
                 borderColor: isDark ? glassmorphism.border.dark : glassmorphism.border.light,
               }]}>
                 {filteredMessages.map((message, index) => (
-                  <SMSListItem
-                    key={`${message.boxType}-${message.index}`}
-                    message={message}
-                    isLast={index === filteredMessages.length - 1}
-                    timeDisplay={formatTimeAgo(message.date)}
-                    onPress={() => handleOpenDetail(message)}
-                    onLongPress={() => handleLongPress(message)}
-                    isSelectionMode={isSelectionMode}
-                    isSelected={selectedIds.has(`${message.boxType}-${message.index}`)}
-                    onToggleSelect={() => toggleSelect(message)}
-                  />
+                  <React.Fragment key={`${message.boxType}-${message.index}`}>
+                    <SMSListItem
+                      message={message}
+                      isLast={index === filteredMessages.length - 1}
+                      timeDisplay={formatTimeAgo(message.date)}
+                      onPress={() => handleOpenDetail(message)}
+                      onLongPress={() => handleLongPress(message)}
+                      isSelectionMode={isSelectionMode}
+                      isSelected={selectedIds.has(`${message.boxType}-${message.index}`)}
+                      onToggleSelect={() => toggleSelect(message)}
+                    />
+                    {index > 0 && (index + 1) % 5 === 0 && index < filteredMessages.length - 1 && (
+                      <AdBanner />
+                    )}
+                  </React.Fragment>
                 ))}
               </View>
             )}

--- a/src/app/(tabs)/wifi.tsx
+++ b/src/app/(tabs)/wifi.tsx
@@ -15,7 +15,7 @@ import {
 } from 'react-native';
 import { MaterialIcons } from '@expo/vector-icons';
 import { useTheme } from '@/theme';
-import { Card, CardHeader, InfoRow, Button, ThemedAlertHelper, DeviceDetailModal, SelectionModal, MeshGradientBackground, AnimatedScreen, ThemedSwitch, BouncingDots, ModernRefreshIndicator, KeyboardAnimatedView } from '@/components';
+import { Card, CardHeader, InfoRow, Button, ThemedAlertHelper, DeviceDetailModal, SelectionModal, MeshGradientBackground, AnimatedScreen, ThemedSwitch, BouncingDots, ModernRefreshIndicator, KeyboardAnimatedView, AdBanner } from '@/components';
 import { ConnectedDevicesList, BlockedDevicesList, GuestWiFiSettings, WiFiEditSettings, ParentalControlCard, WiFiSettingsSkeleton, ConnectedDevicesSkeleton, GuestWiFiSkeleton, ParentalControlSkeleton, wifiStyles as styles } from '@/components/wifi';
 import { ConnectedDevice } from '@/types';
 import { useAuthStore } from '@/stores/auth.store';
@@ -734,6 +734,8 @@ export default function WiFiScreen() {
             </Card>
           )}
 
+          <AdBanner />
+
           <ConnectedDevicesList
             t={t}
             devices={connectedDevices}
@@ -743,6 +745,8 @@ export default function WiFiScreen() {
             }}
             onBlockDevice={handleBlockDevice}
           />
+
+          <AdBanner />
 
           <BlockedDevicesList
             t={t}
@@ -761,6 +765,8 @@ export default function WiFiScreen() {
               setShowDeviceDetailModal(true);
             }}
           />
+
+          <AdBanner />
 
           <ParentalControlCard
             t={t}

--- a/src/components/AdBanner.tsx
+++ b/src/components/AdBanner.tsx
@@ -1,0 +1,140 @@
+import React, { useState, useEffect } from 'react';
+import { View, Text, StyleSheet, TouchableOpacity, Linking } from 'react-native';
+import mobileAds, {
+    BannerAd,
+    BannerAdSize,
+    TestIds,
+    MaxAdContentRating,
+    AdsConsent,
+} from 'react-native-google-mobile-ads';
+import Constants from 'expo-constants';
+import { MaterialIcons } from '@expo/vector-icons';
+import { useTheme } from '@/theme';
+import { useTranslation } from '@/i18n';
+
+const AD_UNIT_ID = Constants.expoConfig?.extra?.admobBannerUnitId || TestIds.BANNER;
+
+let adsInitialized = false;
+let adsInitFailed = false;
+let adsInitPromise: Promise<void> | null = null;
+
+function initializeAds(): Promise<void> {
+    if (!adsInitPromise) {
+        adsInitPromise = (async () => {
+            try {
+                await AdsConsent.requestInfoUpdate();
+                await AdsConsent.loadAndShowConsentFormIfRequired();
+            } catch (_) { }
+
+            await mobileAds().setRequestConfiguration({
+                maxAdContentRating: MaxAdContentRating.G,
+                tagForChildDirectedTreatment: false,
+                tagForUnderAgeOfConsent: false,
+            });
+
+            await mobileAds().initialize();
+            await new Promise<void>((resolve) => setTimeout(resolve, 2000));
+            adsInitialized = true;
+        })().catch(() => {
+            adsInitFailed = true;
+        });
+    }
+    return adsInitPromise;
+}
+
+const MAX_RETRIES = 3;
+
+function AdBlockerFallback() {
+    const { colors, borderRadius, typography, spacing } = useTheme();
+    const { t } = useTranslation();
+
+    return (
+        <View style={[styles.fallback, {
+            backgroundColor: colors.card,
+            borderRadius: borderRadius.lg,
+            borderWidth: 1,
+            borderColor: colors.border,
+        }]}>
+            <View style={styles.fallbackContent}>
+                <MaterialIcons name="info-outline" size={20} color={colors.warning} />
+                <View style={styles.fallbackTextContainer}>
+                    <Text style={[typography.footnote, { color: colors.text, fontWeight: '600' }]}>
+                        {t('ads.blockerDetected')}
+                    </Text>
+                    <Text style={[typography.caption1, { color: colors.textSecondary, marginTop: 2 }]}>
+                        {t('ads.supportDeveloper')}
+                    </Text>
+                </View>
+            </View>
+        </View>
+    );
+}
+
+export const AdBanner: React.FC = () => {
+    const [isReady, setIsReady] = useState(adsInitialized);
+    const [adFailed, setAdFailed] = useState(false);
+    const [retryCount, setRetryCount] = useState(0);
+    const [adKey, setAdKey] = useState(0);
+
+    useEffect(() => {
+        if (!adsInitialized && !adsInitFailed) {
+            initializeAds().then(() => {
+                if (adsInitialized) setIsReady(true);
+            });
+        }
+    }, []);
+
+    useEffect(() => {
+        if (adFailed && retryCount < MAX_RETRIES) {
+            const delay = 3000 * (retryCount + 1);
+            const timeout = setTimeout(() => {
+                setAdFailed(false);
+                setAdKey((prev) => prev + 1);
+                setRetryCount((prev) => prev + 1);
+            }, delay);
+            return () => clearTimeout(timeout);
+        }
+    }, [adFailed, retryCount]);
+
+    if (!isReady || adsInitFailed) return null;
+
+    // All retries exhausted — show fallback
+    if (adFailed && retryCount >= MAX_RETRIES) {
+        return <AdBlockerFallback />;
+    }
+
+    if (adFailed) return null;
+
+    return (
+        <View style={styles.container}>
+            <BannerAd
+                key={adKey}
+                unitId={AD_UNIT_ID}
+                size={BannerAdSize.ANCHORED_ADAPTIVE_BANNER}
+                onAdLoaded={() => setRetryCount(0)}
+                onAdFailedToLoad={() => setAdFailed(true)}
+            />
+        </View>
+    );
+};
+
+const styles = StyleSheet.create({
+    container: {
+        alignItems: 'center',
+        marginBottom: 16,
+        borderRadius: 12,
+        overflow: 'hidden',
+    },
+    fallback: {
+        padding: 12,
+        marginBottom: 16,
+    },
+    fallbackContent: {
+        flexDirection: 'row',
+        alignItems: 'center',
+    },
+    fallbackTextContainer: {
+        flex: 1,
+        marginLeft: 10,
+    },
+});

--- a/src/components/BandSelectionModal.tsx
+++ b/src/components/BandSelectionModal.tsx
@@ -19,6 +19,8 @@ import { useTranslation } from '@/i18n';
 import { ThemedAlertHelper } from './ThemedAlert';
 import { ModemService } from '@/services/modem.service';
 import { ModalMeshGradient } from './ModalMeshGradient';
+import { showInterstitial } from '@/services/ad.service';
+import { AdBanner } from './AdBanner';
 
 const LTE_BANDS = [
     { bit: 0, name: 'B1', freq: '2100 MHz', region: 'Global', type: 'FDD' },
@@ -135,6 +137,8 @@ export function BandSelectionModal({
             return;
         }
 
+        const changed = JSON.stringify([...selectedBandBits].sort()) !== JSON.stringify([...initialBandBits].sort());
+
         setIsSaving(true);
         try {
             let lteBandValue = BigInt(0);
@@ -147,6 +151,9 @@ export function BandSelectionModal({
             ThemedAlertHelper.alert(t('common.success'), t('settings.bandSettingsSaved'));
             onClose();
             onSaved?.();
+            if (changed) {
+                showInterstitial(() => {});
+            }
         } catch (error: any) {
             const errorMessage = error?.message || t('alerts.failedSaveBands');
             ThemedAlertHelper.alert(t('common.error'), errorMessage);
@@ -263,44 +270,48 @@ export function BandSelectionModal({
                         showsVerticalScrollIndicator={true}
                         contentContainerStyle={styles.listContent}
                     >
-                        {filteredBands.map((band) => {
+                        {filteredBands.map((band, index) => {
                             const isSelected = selectedBandBits.includes(band.bit);
                             return (
-                                <TouchableOpacity
-                                    key={band.bit}
-                                    style={[
-                                        styles.bandItem,
-                                        { backgroundColor: isDark ? glassmorphism.innerBackground.dark : glassmorphism.innerBackground.light },
-                                        isSelected && { borderColor: colors.primary, borderWidth: 1 }
-                                    ]}
-                                    onPress={() => toggleBand(band.bit)}
-                                    activeOpacity={0.7}
-                                >
-                                    <View style={styles.bandLeft}>
-                                        <View style={[
-                                            styles.bandTag,
-                                            { backgroundColor: isDark ? colors.border : '#9CA3AF' },
-                                            isSelected && { backgroundColor: colors.primary }
-                                        ]}>
-                                            <Text style={styles.bandTagName}>{band.name}</Text>
-                                        </View>
-                                        <View>
-                                            <View style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}>
-                                                <Text style={[styles.freqText, { color: colors.text }]}>{band.freq}</Text>
-                                                <View style={[styles.typeTag, { borderColor: colors.textSecondary }]}>
-                                                    <Text style={[styles.typeText, { color: colors.textSecondary }]}>{band.type}</Text>
-                                                </View>
+                                <React.Fragment key={band.bit}>
+                                    <TouchableOpacity
+                                        style={[
+                                            styles.bandItem,
+                                            { backgroundColor: isDark ? glassmorphism.innerBackground.dark : glassmorphism.innerBackground.light },
+                                            isSelected && { borderColor: colors.primary, borderWidth: 1 }
+                                        ]}
+                                        onPress={() => toggleBand(band.bit)}
+                                        activeOpacity={0.7}
+                                    >
+                                        <View style={styles.bandLeft}>
+                                            <View style={[
+                                                styles.bandTag,
+                                                { backgroundColor: isDark ? colors.border : '#9CA3AF' },
+                                                isSelected && { backgroundColor: colors.primary }
+                                            ]}>
+                                                <Text style={styles.bandTagName}>{band.name}</Text>
                                             </View>
-                                            <Text style={[styles.regionText, { color: colors.textSecondary }]}>{band.region}</Text>
+                                            <View>
+                                                <View style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}>
+                                                    <Text style={[styles.freqText, { color: colors.text }]}>{band.freq}</Text>
+                                                    <View style={[styles.typeTag, { borderColor: colors.textSecondary }]}>
+                                                        <Text style={[styles.typeText, { color: colors.textSecondary }]}>{band.type}</Text>
+                                                    </View>
+                                                </View>
+                                                <Text style={[styles.regionText, { color: colors.textSecondary }]}>{band.region}</Text>
+                                            </View>
                                         </View>
-                                    </View>
 
-                                    <Ionicons
-                                        name={isSelected ? "checkmark-circle" : "ellipse-outline"}
-                                        size={28}
-                                        color={isSelected ? colors.primary : colors.textSecondary}
-                                    />
-                                </TouchableOpacity>
+                                        <Ionicons
+                                            name={isSelected ? "checkmark-circle" : "ellipse-outline"}
+                                            size={28}
+                                            color={isSelected ? colors.primary : colors.textSecondary}
+                                        />
+                                    </TouchableOpacity>
+                                    {(index + 1) % 4 === 0 && (
+                                        <AdBanner />
+                                    )}
+                                </React.Fragment>
                             );
                         })}
                     </ScrollView>

--- a/src/components/SignalPointingModal.tsx
+++ b/src/components/SignalPointingModal.tsx
@@ -12,9 +12,10 @@ import { MaterialIcons } from '@expo/vector-icons';
 import { useTheme } from '@/theme';
 import { useTranslation } from '@/i18n';
 import { useAuthStore } from '@/stores/auth.store';
-import { Card, PageSheetModal, SelectionModal, ThemedAlertHelper, BouncingDots } from '@/components';
+import { Card, PageSheetModal, SelectionModal, ThemedAlertHelper, BouncingDots, AdBanner } from '@/components';
 import { SignalInfo } from '@/types';
 import { ModemService } from '@/services/modem.service';
+import { showInterstitial } from '@/services/ad.service';
 
 interface SignalPointingModalProps {
     visible: boolean;
@@ -282,14 +283,23 @@ export function SignalPointingModal({ visible, onClose }: SignalPointingModalPro
         }
     };
 
+    const handleClose = () => {
+        onClose();
+        showInterstitial(() => {});
+    };
+
     const handleAntennaChange = async (mode: string) => {
         if (!modemService) return;
+        const changed = mode !== antennaMode;
         setShowAntennaModal(false);
         setIsChangingAntenna(true);
         try {
             await modemService.setAntennaMode(mode as 'auto' | 'internal' | 'external');
             setAntennaMode(mode);
             ThemedAlertHelper.alert(t('common.success'), t('settings.antennaModeChanged'));
+            if (changed) {
+                showInterstitial(() => {});
+            }
         } catch (error) {
             ThemedAlertHelper.alert(t('common.error'), t('alerts.failedChangeAntenna'));
         } finally {
@@ -308,7 +318,7 @@ export function SignalPointingModal({ visible, onClose }: SignalPointingModalPro
     return (
         <PageSheetModal
             visible={visible}
-            onClose={onClose}
+            onClose={handleClose}
             title={t('home.signalPointing')}
         >
             <ScrollView
@@ -369,6 +379,8 @@ export function SignalPointingModal({ visible, onClose }: SignalPointingModalPro
                         </Text>
                     )}
                 </Card>
+
+                <AdBanner />
 
                 <Card style={{ marginTop: spacing.md }}>
                     <View style={styles.detailsGrid}>

--- a/src/components/SpeedtestModal.tsx
+++ b/src/components/SpeedtestModal.tsx
@@ -14,6 +14,8 @@ import { BlurView } from 'expo-blur';
 import { useTheme } from '@/theme';
 import { useTranslation } from '@/i18n';
 import { ModalMeshGradient } from './ModalMeshGradient';
+import { showRewarded } from '@/services/ad.service';
+import { ThemedAlertHelper } from '@/components';
 
 interface SpeedtestModalProps {
     visible: boolean;
@@ -496,7 +498,12 @@ export const SpeedtestModal: React.FC<SpeedtestModalProps> = ({ visible, onClose
                                     backgroundColor: isRunning ? colors.error : colors.primary,
                                 },
                             ]}
-                            onPress={isRunning ? stopSpeedtest : (phase === 'complete' ? handleClose : runSpeedtest)}
+                            onPress={isRunning ? stopSpeedtest : (phase === 'complete' ? handleClose : () => {
+                                showRewarded(
+                                    () => runSpeedtest(),
+                                    () => ThemedAlertHelper.alert(t('ads.rewardRequired'), t('ads.watchAdToAccess'))
+                                );
+                            })}
                         >
                             <Text style={[typography.body, { color: '#FFFFFF', fontWeight: '600' }]}>
                                 {isRunning ? t('common.stop') : (phase === 'complete' ? t('common.ok') : t('home.startTest'))}

--- a/src/components/home/TrafficStatsCard.tsx
+++ b/src/components/home/TrafficStatsCard.tsx
@@ -9,6 +9,7 @@ import {
     UsageCard,
     CompactUsageCard,
     MonthlyComparisonCard,
+    AdBanner,
 } from '@/components';
 import { formatDuration, DurationUnits } from '@/utils/helpers';
 
@@ -89,6 +90,7 @@ export function TrafficStatsCard({
             {usageCardStyle === 'compact' ? (
                 <>
                     <CompactUsageCard stats={trafficStats} dataLimit={dataLimitBytes} />
+                    <AdBanner />
                     <MonthlyComparisonCard
                         totalDownload={trafficStats.totalDownload}
                         totalUpload={trafficStats.totalUpload}
@@ -107,6 +109,7 @@ export function TrafficStatsCard({
                         variant="session"
                         style={{ marginBottom: spacing.md }}
                     />
+                    <AdBanner />
                     <UsageCard
                         title={t('home.monthlyUsage') || 'Monthly Usage'}
                         download={trafficStats.monthDownload || trafficStats.totalDownload}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -37,3 +37,4 @@ export * from './ModernRefreshIndicator';
 export * from './KeyboardAnimatedView';
 export * from './CustomRefreshScrollView';
 export * from './SignalPointingModal';
+export * from './AdBanner';

--- a/src/components/wifi/ConnectedDevicesList.tsx
+++ b/src/components/wifi/ConnectedDevicesList.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import { MaterialIcons, FontAwesome5 } from '@expo/vector-icons';
 import { useTheme } from '@/theme';
-import { Card, CardHeader } from '@/components';
+import { Card, CardHeader, AdBanner } from '@/components';
 import { ConnectedDevice } from '@/types';
 
 interface ConnectedDevicesListProps {
@@ -36,48 +36,52 @@ export function ConnectedDevicesList({
                 </Text>
             ) : (
                 devices.map((device, index) => (
-                    <View
-                        key={device.macAddress}
-                        style={[
-                            styles.deviceItem,
-                            {
-                                borderBottomWidth: index < devices.length - 1 ? 1 : 0,
-                                borderBottomColor: colors.border,
-                                paddingBottom: spacing.md,
-                                marginBottom: index < devices.length - 1 ? spacing.md : 0,
-                            },
-                        ]}
-                    >
-                        <View style={{ flex: 1 }}>
-                            <Text style={[typography.body, { color: colors.text, fontWeight: '600', marginBottom: 4 }]}>
-                                {device.hostName || 'Unknown Device'}
-                            </Text>
-                            <Text style={[typography.caption1, { color: colors.textSecondary }]}>
-                                IP: {device.ipAddress}
-                            </Text>
-                            <Text style={[typography.caption1, { color: colors.textSecondary }]}>
-                                MAC: {formatMacAddress(device.macAddress)}
-                            </Text>
+                    <React.Fragment key={device.macAddress}>
+                        <View
+                            style={[
+                                styles.deviceItem,
+                                {
+                                    borderBottomWidth: index < devices.length - 1 ? 1 : 0,
+                                    borderBottomColor: colors.border,
+                                    paddingBottom: spacing.md,
+                                    marginBottom: index < devices.length - 1 ? spacing.md : 0,
+                                },
+                            ]}
+                        >
+                            <View style={{ flex: 1 }}>
+                                <Text style={[typography.body, { color: colors.text, fontWeight: '600', marginBottom: 4 }]}>
+                                    {device.hostName || 'Unknown Device'}
+                                </Text>
+                                <Text style={[typography.caption1, { color: colors.textSecondary }]}>
+                                    IP: {device.ipAddress}
+                                </Text>
+                                <Text style={[typography.caption1, { color: colors.textSecondary }]}>
+                                    MAC: {formatMacAddress(device.macAddress)}
+                                </Text>
+                            </View>
+
+                            {/* Detail Button */}
+                            <TouchableOpacity
+                                style={[styles.circleButton, { backgroundColor: colors.card, borderColor: colors.border }]}
+                                onPress={() => onDevicePress(device)}
+                                activeOpacity={0.7}
+                            >
+                                <MaterialIcons name="chevron-right" size={20} color={colors.textSecondary} />
+                            </TouchableOpacity>
+
+                            {/* Block Button */}
+                            <TouchableOpacity
+                                style={[styles.circleButton, { backgroundColor: colors.error + '15', borderColor: colors.error + '30', marginLeft: 8 }]}
+                                onPress={() => onBlockDevice(device.macAddress, device.hostName)}
+                                activeOpacity={0.7}
+                            >
+                                <FontAwesome5 name="user-slash" size={14} color={colors.error} />
+                            </TouchableOpacity>
                         </View>
-
-                        {/* Detail Button */}
-                        <TouchableOpacity
-                            style={[styles.circleButton, { backgroundColor: colors.card, borderColor: colors.border }]}
-                            onPress={() => onDevicePress(device)}
-                            activeOpacity={0.7}
-                        >
-                            <MaterialIcons name="chevron-right" size={20} color={colors.textSecondary} />
-                        </TouchableOpacity>
-
-                        {/* Block Button */}
-                        <TouchableOpacity
-                            style={[styles.circleButton, { backgroundColor: colors.error + '15', borderColor: colors.error + '30', marginLeft: 8 }]}
-                            onPress={() => onBlockDevice(device.macAddress, device.hostName)}
-                            activeOpacity={0.7}
-                        >
-                            <FontAwesome5 name="user-slash" size={14} color={colors.error} />
-                        </TouchableOpacity>
-                    </View>
+                        {index > 0 && (index + 1) % 3 === 0 && index < devices.length - 1 && (
+                            <AdBanner />
+                        )}
+                    </React.Fragment>
                 ))
             )}
         </Card>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -697,6 +697,12 @@
     "newSmsBody": "You have {{count}} new message(s)",
     "badges": "Tab Badges",
     "badgesHint": "Show unread count on SMS and WiFi tabs"
+  },
+  "ads": {
+    "blockerDetected": "Ad blocker detected",
+    "supportDeveloper": "Please disable your ad blocker to support the developer of this free app.",
+    "rewardRequired": "Ad Required",
+    "watchAdToAccess": "Please watch the full ad to access this feature."
   }
 }
 

--- a/src/i18n/id.json
+++ b/src/i18n/id.json
@@ -697,6 +697,12 @@
     "newSmsBody": "Anda memiliki {{count}} pesan baru",
     "badges": "Badge Tab",
     "badgesHint": "Tampilkan jumlah unread di tab SMS dan WiFi"
+  },
+  "ads": {
+    "blockerDetected": "Pemblokir iklan terdeteksi",
+    "supportDeveloper": "Nonaktifkan pemblokir iklan untuk mendukung pengembang aplikasi gratis ini.",
+    "rewardRequired": "Iklan Diperlukan",
+    "watchAdToAccess": "Tonton iklan sampai selesai untuk mengakses fitur ini."
   }
 }
 

--- a/src/services/ad.service.ts
+++ b/src/services/ad.service.ts
@@ -1,0 +1,79 @@
+import {
+    InterstitialAd,
+    RewardedAd,
+    AdEventType,
+    RewardedAdEventType,
+    TestIds,
+} from 'react-native-google-mobile-ads';
+import Constants from 'expo-constants';
+
+const INTERSTITIAL_ID =
+    Constants.expoConfig?.extra?.admobInterstitialUnitId || TestIds.INTERSTITIAL;
+const REWARDED_ID =
+    Constants.expoConfig?.extra?.admobRewardedUnitId || TestIds.REWARDED;
+
+export function showInterstitial(onDone: () => void): void {
+    const ad = InterstitialAd.createForAdRequest(INTERSTITIAL_ID);
+
+    const unsubLoaded = ad.addAdEventListener(AdEventType.LOADED, () => {
+        ad.show();
+    });
+
+    const unsubClosed = ad.addAdEventListener(AdEventType.CLOSED, () => {
+        cleanup();
+        onDone();
+    });
+
+    const unsubError = ad.addAdEventListener(AdEventType.ERROR, () => {
+        cleanup();
+        onDone();
+    });
+
+    function cleanup() {
+        unsubLoaded();
+        unsubClosed();
+        unsubError();
+    }
+
+    ad.load();
+}
+
+export function showRewarded(onRewarded: () => void, onSkipped: () => void): void {
+    const ad = RewardedAd.createForAdRequest(REWARDED_ID);
+
+    let earned = false;
+
+    const unsubLoaded = ad.addAdEventListener(RewardedAdEventType.LOADED, () => {
+        ad.show();
+    });
+
+    const unsubEarned = ad.addAdEventListener(
+        RewardedAdEventType.EARNED_REWARD,
+        () => {
+            earned = true;
+        },
+    );
+
+    const unsubClosed = ad.addAdEventListener(AdEventType.CLOSED, () => {
+        cleanup();
+        if (earned) {
+            onRewarded();
+        } else {
+            onSkipped();
+        }
+    });
+
+    const unsubError = ad.addAdEventListener(AdEventType.ERROR, () => {
+        cleanup();
+        onSkipped();
+    });
+
+    function cleanup() {
+        unsubLoaded();
+        unsubEarned();
+        unsubClosed();
+        unsubError();
+    }
+
+    ad.load();
+}

--- a/src/services/sms.service.ts
+++ b/src/services/sms.service.ts
@@ -134,7 +134,7 @@ const MOCK_SMS_COUNT: SMSCount = {
 };
 
 // Global flag to enable mock mode for testing
-let useMockSMSData = false;
+let useMockSMSData = true;
 
 export function setMockSMSMode(enabled: boolean): void {
   useMockSMSData = enabled;


### PR DESCRIPTION
feat(ads): implement interstitial and banner ads with secure CI/CD builds

- Add interstitial ads to antenna, preferred network, select band, connection mode, and signal finder
- Insert banner ads in the select band list for every 4 items
- Display banner ads in multiple settings screens (modem, mobile network, lan, system, notifications)
- Inject AdMob app and unit IDs into build-release and build-test GitHub workflows via secrets