### PR TITLE
feat(home): add rewards gate, speedtest hostname & startup adblock alert

### DIFF
--- a/src/app/(tabs)/home.tsx
+++ b/src/app/(tabs)/home.tsx
@@ -111,6 +111,15 @@ export default function HomeScreen() {
       }
     };
     loadLastClearedDate();
+
+    // Show warning about adblockers on startup
+    setTimeout(() => {
+      ThemedAlertHelper.alert(
+        t('ads.adblockNoticeTitle'),
+        t('ads.adblockNoticeMessage'),
+        [{ text: t('common.ok') }]
+      );
+    }, 1500);
   }, []);
 
   useEffect(() => {
@@ -475,28 +484,32 @@ export default function HomeScreen() {
         { text: t('common.cancel'), style: 'cancel' },
         {
           text: t('common.continue'),
-          onPress: async () => {
-            setIsChangingIp(true);
+          onPress: () => {
+            showRewarded(
+              async () => {
+                setIsChangingIp(true);
 
-            ThemedAlertHelper.alert(
-              t('alerts.ipChangeStartedTitle'),
-              t('alerts.ipChangeStartedMessage'),
-              [{ text: t('common.ok') }]
+                ThemedAlertHelper.alert(
+                  t('alerts.ipChangeStartedTitle'),
+                  t('alerts.ipChangeStartedMessage'),
+                  [{ text: t('common.ok') }]
+                );
+
+                modemService.triggerPlmnScan().catch((error) => {
+                });
+
+                setTimeout(() => {
+                  setIsChangingIp(false);
+                }, 10000);
+
+                setTimeout(() => {
+                  if (modemService) {
+                    loadData(modemService);
+                  }
+                }, 45000);
+              },
+              () => ThemedAlertHelper.alert(t('ads.rewardRequired'), t('ads.watchAdToAccess'))
             );
-            showInterstitial(() => { });
-
-            modemService.triggerPlmnScan().catch((error) => {
-            });
-
-            setTimeout(() => {
-              setIsChangingIp(false);
-            }, 10000);
-
-            setTimeout(() => {
-              if (modemService) {
-                loadData(modemService);
-              }
-            }, 45000);
           },
         },
       ]
@@ -773,10 +786,17 @@ export default function HomeScreen() {
             onOpenBandModal={() => setShowBandModal(true)}
             onChangeIp={handleChangeIp}
             onToggleMobileData={handleToggleMobileData}
-            onSignalPointing={() => setShowSignalPointingModal(true)}
+            onSignalPointing={() => {
+              showRewarded(
+                () => setShowSignalPointingModal(true),
+                () => ThemedAlertHelper.alert(t('ads.rewardRequired'), t('ads.watchAdToAccess'))
+              );
+            }}
             onQuickCheck={handleOneClickCheck}
             onSpeedtest={() => setShowSpeedtestModal(true)}
           />
+
+          <AdBanner />
 
           <SignalInfoCard
             t={t}

--- a/src/components/BandSelectionModal.tsx
+++ b/src/components/BandSelectionModal.tsx
@@ -19,7 +19,7 @@ import { useTranslation } from '@/i18n';
 import { ThemedAlertHelper } from './ThemedAlert';
 import { ModemService } from '@/services/modem.service';
 import { ModalMeshGradient } from './ModalMeshGradient';
-import { showInterstitial } from '@/services/ad.service';
+import { showInterstitial, showRewarded } from '@/services/ad.service';
 import { AdBanner } from './AdBanner';
 
 const LTE_BANDS = [
@@ -139,26 +139,33 @@ export function BandSelectionModal({
 
         const changed = JSON.stringify([...selectedBandBits].sort()) !== JSON.stringify([...initialBandBits].sort());
 
-        setIsSaving(true);
-        try {
-            let lteBandValue = BigInt(0);
-            for (const bit of selectedBandBits) {
-                lteBandValue |= (BigInt(1) << BigInt(bit));
-            }
-            const lteBandHex = lteBandValue.toString(16).toUpperCase();
+        if (changed) {
+            showRewarded(
+                async () => {
+                    setIsSaving(true);
+                    try {
+                        let lteBandValue = BigInt(0);
+                        for (const bit of selectedBandBits) {
+                            lteBandValue |= (BigInt(1) << BigInt(bit));
+                        }
+                        const lteBandHex = lteBandValue.toString(16).toUpperCase();
 
-            await modemService.setBandSettings('3FFFFFFF', lteBandHex);
-            ThemedAlertHelper.alert(t('common.success'), t('settings.bandSettingsSaved'));
+                        await modemService.setBandSettings('3FFFFFFF', lteBandHex);
+                        ThemedAlertHelper.alert(t('common.success'), t('settings.bandSettingsSaved'));
+                        onClose();
+                        onSaved?.();
+                    } catch (error: any) {
+                        const errorMessage = error?.message || t('alerts.failedSaveBands');
+                        ThemedAlertHelper.alert(t('common.error'), errorMessage);
+                    } finally {
+                        setIsSaving(false);
+                    }
+                },
+                () => ThemedAlertHelper.alert(t('ads.rewardRequired'), t('ads.watchAdToAccess'))
+            );
+        } else {
+            // If no changes, just close the modal
             onClose();
-            onSaved?.();
-            if (changed) {
-                showInterstitial(() => {});
-            }
-        } catch (error: any) {
-            const errorMessage = error?.message || t('alerts.failedSaveBands');
-            ThemedAlertHelper.alert(t('common.error'), errorMessage);
-        } finally {
-            setIsSaving(false);
         }
     };
 

--- a/src/components/DeviceDetailModal.tsx
+++ b/src/components/DeviceDetailModal.tsx
@@ -19,6 +19,7 @@ import { useTheme } from '@/theme';
 import { useTranslation } from '@/i18n';
 import { ConnectedDevice } from '@/types';
 import { MeshGradientBackground } from './MeshGradientBackground';
+import { AdBanner } from './AdBanner';
 
 interface DeviceDetailModalProps {
     visible: boolean;
@@ -160,6 +161,7 @@ export function DeviceDetailModal({
                             <Text style={[styles.sectionTitle, { color: colors.text }]}>
                                 {t('wifi.deviceName')}
                             </Text>
+                            <AdBanner />
                             <View style={[styles.card, { backgroundColor: colors.card, borderColor: colors.border }]}>
                                 <TextInput
                                     style={[styles.input, { color: colors.text }]}
@@ -207,6 +209,7 @@ export function DeviceDetailModal({
                                 </View>
                             </View>
                         </View>
+                        <AdBanner />
 
                         <View style={styles.section}>
                             <Text style={[styles.sectionTitle, { color: colors.text }]}>

--- a/src/components/MonthlySettingsModal.tsx
+++ b/src/components/MonthlySettingsModal.tsx
@@ -20,6 +20,8 @@ import { useTranslation } from '@/i18n';
 import { MeshGradientBackground } from './MeshGradientBackground';
 import { ThemedSwitch } from './ThemedSwitch';
 import { ThemedAlertHelper } from './ThemedAlert';
+import { AdBanner } from './AdBanner';
+
 
 interface MonthlySettingsModalProps {
     visible: boolean;
@@ -169,6 +171,8 @@ export function MonthlySettingsModal({
                             />
                         </View>
 
+                        <AdBanner />
+
                         <View style={styles.section}>
                             <Text style={[styles.sectionTitle, { color: colors.text }]}>{t('home.startDate')}</Text>
                             <View style={[styles.dateCard, { borderColor: colors.border, backgroundColor: colors.background }]}>
@@ -245,6 +249,8 @@ export function MonthlySettingsModal({
                                 </View>
                             )}
                         </View>
+
+                        <AdBanner />
 
                         <View style={styles.section}>
                             <Text style={[styles.sectionTitle, { color: colors.text }]}>{t('home.threshold').replace(' (%)', '')}</Text>

--- a/src/components/SpeedGauge.tsx
+++ b/src/components/SpeedGauge.tsx
@@ -20,8 +20,8 @@ export function SpeedGauge({ downloadSpeed, uploadSpeed }: SpeedGaugeProps) {
         return { value, unit: sizes[i] };
     };
 
-    const dlSpeed = formatSpeed(downloadSpeed);
-    const ulSpeed = formatSpeed(uploadSpeed);
+    const dlSpeed = formatSpeed(downloadSpeed * 8);
+    const ulSpeed = formatSpeed(uploadSpeed * 8);
 
     const size = 140;
     const strokeWidth = 10;
@@ -35,7 +35,7 @@ export function SpeedGauge({ downloadSpeed, uploadSpeed }: SpeedGaugeProps) {
     const getPoint = (angle: number, r: number) => ({
         x: center + Math.cos(angle) * r,
         y: center + Math.sin(angle) * r,
-    });
+    })
 
     const createArc = (start: number, end: number, r: number) => {
         const p1 = getPoint(start, r);
@@ -148,7 +148,7 @@ export function SpeedGauge({ downloadSpeed, uploadSpeed }: SpeedGaugeProps) {
         <View style={styles.container}>
             <View style={styles.gaugesRow}>
                 {renderGauge(
-                    downloadSpeed,
+                    downloadSpeed * 8,
                     dlSpeed.value,
                     dlSpeed.unit,
                     downloadColors.primary,
@@ -157,7 +157,7 @@ export function SpeedGauge({ downloadSpeed, uploadSpeed }: SpeedGaugeProps) {
                     'dlGrad'
                 )}
                 {renderGauge(
-                    uploadSpeed,
+                    uploadSpeed * 8,
                     ulSpeed.value,
                     ulSpeed.unit,
                     uploadColors.primary,

--- a/src/components/SpeedtestModal.tsx
+++ b/src/components/SpeedtestModal.tsx
@@ -9,7 +9,7 @@ import {
     Easing,
     Platform,
 } from 'react-native';
-import { MaterialIcons } from '@expo/vector-icons';
+import { MaterialIcons, Ionicons } from '@expo/vector-icons';
 import { BlurView } from 'expo-blur';
 import { useTheme } from '@/theme';
 import { useTranslation } from '@/i18n';
@@ -204,6 +204,52 @@ export const SpeedtestModal: React.FC<SpeedtestModalProps> = ({ visible, onClose
     const [progress, setProgress] = useState(0);
     const progressAnim = useRef(new Animated.Value(0)).current;
     const abortControllerRef = useRef<AbortController | null>(null);
+    const progressIntervalRef = useRef<NodeJS.Timeout | null>(null);
+
+    const [clientIp, setClientIp] = useState<string>('');
+    const [ispInfo, setIspInfo] = useState<string>('');
+    const [providerHostname, setProviderHostname] = useState<string>('');
+
+    useEffect(() => {
+        if (visible) {
+            fetch('https://ipinfo.io/json')
+                .then(res => res.json())
+                .then(data => {
+                    if (data.ip) {
+                        setClientIp(data.ip);
+                    }
+                    if (data.org) {
+                        const cleanIsp = data.org.replace(/^AS\d+\s+/, '');
+                        setIspInfo(cleanIsp);
+                    } else if (data.isp) {
+                        setIspInfo(data.isp);
+                    }
+                    if (data.hostname) {
+                        setProviderHostname(data.hostname);
+                    }
+                })
+                .catch(() => {
+                    // Fallback to speed.cloudflare.com
+                    fetch('https://speed.cloudflare.com/meta')
+                        .then(res => res.json())
+                        .then(data => {
+                            if (data.clientIp) {
+                                setClientIp(data.clientIp);
+                            }
+                            if (data.clientIsp) {
+                                setIspInfo(data.clientIsp);
+                            }
+                        })
+                        .catch(() => {
+                            setClientIp('Unknown');
+                        });
+                });
+        } else {
+            setClientIp('');
+            setIspInfo('');
+            setProviderHostname('');
+        }
+    }, [visible]);
 
     useEffect(() => {
         Animated.timing(progressAnim, {
@@ -222,15 +268,15 @@ export const SpeedtestModal: React.FC<SpeedtestModalProps> = ({ visible, onClose
         const signal = abortControllerRef.current.signal;
 
         try {
+            // 1. LATENCY & JITTER PHASE
             setPhase('latency');
-
             const latencyResults: number[] = [];
 
             try {
                 await fetch(`${CF_DOWNLOAD_URL}?bytes=0`, { signal });
             } catch { }
 
-            for (let i = 0; i < 20; i++) {
+            for (let i = 0; i < 10; i++) {
                 if (signal.aborted) throw new Error('Aborted');
                 const start = performance.now();
                 try {
@@ -242,9 +288,10 @@ export const SpeedtestModal: React.FC<SpeedtestModalProps> = ({ visible, onClose
                     latencyResults.push(latency);
                 } catch (e: any) {
                     if (e.name !== 'AbortError') {
+                        // ignore error and continue
                     }
                 }
-                setProgress((i + 1));
+                setProgress(Math.round(((i + 1) / 10) * 20));
             }
 
             const validLatency = latencyResults.filter(l => l > 0 && l < 10000);
@@ -253,134 +300,120 @@ export const SpeedtestModal: React.FC<SpeedtestModalProps> = ({ visible, onClose
             const avg = validLatency.reduce((a, b) => a + b, 0) / validLatency.length;
             const jitter = Math.sqrt(validLatency.reduce((s, l) => s + Math.pow(l - avg, 2), 0) / validLatency.length);
 
-            setResult(prev => ({ ...prev, latency: median, jitter }));
+            setResult(prev => ({ ...prev, latency: median, jitter: isNaN(jitter) ? 0 : jitter }));
             setProgress(20);
 
+            if (signal.aborted) throw new Error('Aborted');
+
+            // 2. DOWNLOAD SPEED PHASE
             setPhase('download');
+            
+            // Set up smooth progress increment from 20 to 60
+            if (progressIntervalRef.current) clearInterval(progressIntervalRef.current);
+            progressIntervalRef.current = setInterval(() => {
+                setProgress(prev => Math.min(prev + 0.8, 59));
+            }, 100);
 
-            const downloadSizes = [
-                { bytes: 100000, count: 1 },
-                { bytes: 100000, count: 8 },
-                { bytes: 1000000, count: 6 },
-                { bytes: 10000000, count: 4 },
-                { bytes: 25000000, count: 2 },
-            ];
+            const dlDurationMs = 6000; // 6 seconds test duration
+            const dlStartTime = performance.now();
+            let totalBytesDownloaded = 0;
+            const DL_CHUNK_SIZE = 1000000; // 1MB chunks
 
-            const downloadSpeeds: number[] = [];
-            let downloadCount = 0;
-            const totalDownloads = downloadSizes.reduce((sum, s) => sum + s.count, 0);
-
-            for (const { bytes, count } of downloadSizes) {
-                if (signal.aborted) break;
-
-                for (let i = 0; i < count; i++) {
-                    if (signal.aborted) break;
-
-                    const start = performance.now();
+            const downloadWorker = async () => {
+                while (performance.now() - dlStartTime < dlDurationMs && !signal.aborted) {
                     try {
-                        const response = await fetch(`${CF_DOWNLOAD_URL}?bytes=${bytes}`, {
+                        const res = await fetch(`${CF_DOWNLOAD_URL}?bytes=${DL_CHUNK_SIZE}`, {
                             cache: 'no-store',
-                            signal,
+                            signal
                         });
-                        const buffer = await response.arrayBuffer();
-                        const duration = (performance.now() - start) / 1000;
+                        const buffer = await res.arrayBuffer();
+                        if (signal.aborted) break;
 
-                        const transferSize = buffer.byteLength;
-                        const speedBps = (transferSize * 8) / duration;
-                        const speedMbps = speedBps / 1000000;
-
-                        downloadSpeeds.push(speedMbps);
-
-                        setResult(prev => ({ ...prev, downloadSpeed: speedMbps }));
-
-                    } catch (e: any) {
-                        if (e.name !== 'AbortError') {
+                        totalBytesDownloaded += buffer.byteLength;
+                        const elapsed = (performance.now() - dlStartTime) / 1000;
+                        if (elapsed > 0) {
+                            const speedMbps = ((totalBytesDownloaded * 8) / elapsed) / 1000000;
+                            setResult(prev => ({ ...prev, downloadSpeed: speedMbps }));
                         }
+                    } catch (err) {
+                        if (signal.aborted) break;
                     }
-
-                    downloadCount++;
-                    setProgress(20 + (downloadCount / totalDownloads) * 40);
                 }
-            }
+            };
 
-            const sortedSpeeds = [...downloadSpeeds].sort((a, b) => a - b);
-            const p90Index = Math.floor(sortedSpeeds.length * 0.9);
-            const downloadP90 = sortedSpeeds[p90Index] || sortedSpeeds[sortedSpeeds.length - 1] || 0;
+            // Run 3 workers in parallel to saturate bandwidth
+            await Promise.all([downloadWorker(), downloadWorker(), downloadWorker()]);
 
-            setResult(prev => ({ ...prev, downloadSpeed: downloadP90 }));
+            if (progressIntervalRef.current) clearInterval(progressIntervalRef.current);
             setProgress(60);
 
+            if (signal.aborted) throw new Error('Aborted');
+
+            // 3. UPLOAD SPEED PHASE
             setPhase('upload');
-            const uploadSizes = [
-                { bytes: 100000, count: 4 },
-                { bytes: 500000, count: 4 },
-                { bytes: 1000000, count: 2 },
-                { bytes: 5000000, count: 1 },
-            ];
 
-            const uploadSpeeds: number[] = [];
-            let uploadCount = 0;
-            const totalUploads = uploadSizes.reduce((sum, s) => sum + s.count, 0);
+            // Set up smooth progress increment from 60 to 95
+            progressIntervalRef.current = setInterval(() => {
+                setProgress(prev => Math.min(prev + 0.6, 94));
+            }, 100);
 
-            const uploadUrl = 'https://postman-echo.com/post';
+            const ulDurationMs = 6000; // 6 seconds test duration
+            const ulStartTime = performance.now();
+            let totalBytesUploaded = 0;
+            const UL_CHUNK_SIZE = 500000; // 500KB chunks
 
-            for (const { bytes, count } of uploadSizes) {
-                if (signal.aborted) break;
+            // Pre-generate random payload once to save device CPU
+            const uploadData = new Uint8Array(UL_CHUNK_SIZE);
+            for (let i = 0; i < UL_CHUNK_SIZE; i++) {
+                uploadData[i] = Math.floor(Math.random() * 256);
+            }
 
-                const uploadData = new Uint8Array(bytes);
-                for (let i = 0; i < bytes; i++) {
-                    uploadData[i] = Math.floor(Math.random() * 256);
-                }
-
-                for (let i = 0; i < count; i++) {
-                    if (signal.aborted) break;
-
-                    const start = performance.now();
+            const uploadWorker = async () => {
+                while (performance.now() - ulStartTime < ulDurationMs && !signal.aborted) {
                     try {
-                        await fetch(uploadUrl, {
+                        await fetch(CF_UPLOAD_URL, {
                             method: 'POST',
                             body: uploadData,
                             headers: { 'Content-Type': 'application/octet-stream' },
                             signal,
                         });
-                        const duration = (performance.now() - start) / 1000;
+                        if (signal.aborted) break;
 
-                        const speedBps = (bytes * 8) / duration;
-                        const speedMbps = speedBps / 1000000;
-
-                        uploadSpeeds.push(speedMbps);
-
-                        setResult(prev => ({ ...prev, uploadSpeed: speedMbps }));
-
-                    } catch (e: any) {
-                        if (e.name !== 'AbortError') {
+                        totalBytesUploaded += UL_CHUNK_SIZE;
+                        const elapsed = (performance.now() - ulStartTime) / 1000;
+                        if (elapsed > 0) {
+                            const speedMbps = ((totalBytesUploaded * 8) / elapsed) / 1000000;
+                            setResult(prev => ({ ...prev, uploadSpeed: speedMbps }));
                         }
+                    } catch (err) {
+                        if (signal.aborted) break;
                     }
-
-                    uploadCount++;
-                    setProgress(60 + (uploadCount / totalUploads) * 35);
                 }
-            }
+            };
 
-            const sortedUploadSpeeds = [...uploadSpeeds].sort((a, b) => a - b);
-            const uploadP90Index = Math.floor(sortedUploadSpeeds.length * 0.9);
-            const uploadP90 = sortedUploadSpeeds[uploadP90Index] || sortedUploadSpeeds[sortedUploadSpeeds.length - 1] || 0;
+            // Run 3 workers in parallel to saturate upload bandwidth
+            await Promise.all([uploadWorker(), uploadWorker(), uploadWorker()]);
 
-            setResult(prev => ({ ...prev, uploadSpeed: uploadP90 }));
+            if (progressIntervalRef.current) clearInterval(progressIntervalRef.current);
             setProgress(100);
 
             setPhase('complete');
         } catch (error: any) {
+            if (progressIntervalRef.current) clearInterval(progressIntervalRef.current);
             if (error.message !== 'Aborted') {
                 console.error('[SPEEDTEST] Error:', error.message);
             }
             setPhase('complete');
         } finally {
+            if (progressIntervalRef.current) clearInterval(progressIntervalRef.current);
             setIsRunning(false);
         }
     };
 
     const stopSpeedtest = () => {
+        if (progressIntervalRef.current) {
+            clearInterval(progressIntervalRef.current);
+        }
         if (abortControllerRef.current) {
             abortControllerRef.current.abort();
         }
@@ -395,6 +428,9 @@ export const SpeedtestModal: React.FC<SpeedtestModalProps> = ({ visible, onClose
         setPhase('idle');
         setProgress(0);
         setResult({ downloadSpeed: 0, uploadSpeed: 0, latency: 0, jitter: 0 });
+        setClientIp('');
+        setIspInfo('');
+        setProviderHostname('');
         onClose();
     };
 
@@ -437,6 +473,26 @@ export const SpeedtestModal: React.FC<SpeedtestModalProps> = ({ visible, onClose
                                 <MaterialIcons name="close" size={24} color={colors.textSecondary} />
                             </TouchableOpacity>
                         </View>
+
+                        {(clientIp !== '' || ispInfo !== '' || providerHostname !== '') && (
+                            <View style={{ marginBottom: 16, alignItems: 'center', backgroundColor: isDark ? 'rgba(255,255,255,0.05)' : 'rgba(0,0,0,0.03)', borderRadius: 12, paddingVertical: 8, paddingHorizontal: 12, width: '100%' }}>
+                                {ispInfo !== '' && (
+                                    <Text style={[typography.caption1, { color: colors.textSecondary }]}>
+                                        <Ionicons name="earth" size={12} color={colors.textSecondary} /> <Text style={{ color: colors.text, fontWeight: '600' }}>{ispInfo}</Text>
+                                    </Text>
+                                )}
+                                {clientIp !== '' && (
+                                    <Text style={[typography.caption1, { color: colors.textSecondary, marginTop: 2 }]}>
+                                        <MaterialIcons name="network-wifi" size={12} color={colors.textSecondary} /> <Text style={{ color: colors.text, fontWeight: '600' }}>{clientIp}</Text>
+                                    </Text>
+                                )}
+                                {providerHostname !== '' && providerHostname !== clientIp && (
+                                    <Text style={[typography.caption1, { color: colors.textSecondary, marginTop: 2, textAlign: 'center' }]}>
+                                        <MaterialIcons name="computer" size={12} color={colors.textSecondary} /> <Text style={{ color: colors.text, fontWeight: '600' }}>{providerHostname}</Text>
+                                    </Text>
+                                )}
+                            </View>
+                        )}
 
                         {isRunning && (
                             <View style={[styles.progressContainer, { backgroundColor: colors.border }]}>

--- a/src/components/home/TrafficStatsCard.tsx
+++ b/src/components/home/TrafficStatsCard.tsx
@@ -79,6 +79,8 @@ export function TrafficStatsCard({
 
             <View style={{ height: 1, backgroundColor: colors.border, marginVertical: spacing.md }} />
 
+            <AdBanner />
+
             {trafficStats.dayUsed > 0 && (
                 <DailyUsageCard
                     usage={trafficStats.dayUsed}
@@ -119,6 +121,7 @@ export function TrafficStatsCard({
                         variant="monthly"
                         dataLimit={dataLimitBytes}
                     />
+                    <AdBanner />
                     <UsageCard
                         title={t('home.totalUsage') || 'Total Usage'}
                         badge={formatDuration(trafficStats.totalConnectTime, durationUnits)}

--- a/src/components/wifi/ParentalControlCard.tsx
+++ b/src/components/wifi/ParentalControlCard.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { View, Text, TouchableOpacity } from 'react-native';
 import { MaterialIcons } from '@expo/vector-icons';
 import { useTheme } from '@/theme';
-import { Card, CardHeader, Button, ThemedSwitch, BouncingDots } from '@/components';
+import { Card, CardHeader, Button, ThemedSwitch, BouncingDots, AdBanner } from '@/components';
 import { wifiStyles as styles } from './wifiStyles';
 
 interface ParentalProfile {
@@ -86,10 +86,12 @@ export function ParentalControlCard({
                     size={24}
                     color={colors.textSecondary}
                 />
+
             </TouchableOpacity>
 
             {isParentalExpanded && (
                 <View style={{ marginTop: spacing.md }}>
+                    <AdBanner />
                     {parentalProfiles.length === 0 ? (
                         <Text style={[typography.body, { color: colors.textSecondary, textAlign: 'center', paddingVertical: spacing.md }]}>
                             {t('parentalControl.noProfiles')}
@@ -125,6 +127,7 @@ export function ParentalControlCard({
                                     <Text style={[typography.caption1, { color: colors.textSecondary }]}>
                                         {profile.deviceMacs.length} {t('parentalControl.selectDevices').toLowerCase()}
                                     </Text>
+                                    <AdBanner />
                                 </View>
                                 <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
                                     <TouchableOpacity

--- a/src/components/wifi/WiFiEditSettings.tsx
+++ b/src/components/wifi/WiFiEditSettings.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { View, Text, TouchableOpacity, TextInput } from 'react-native';
 import { MaterialIcons } from '@expo/vector-icons';
 import { useTheme } from '@/theme';
-import { SelectionModal, BouncingDots } from '@/components';
+import { SelectionModal, BouncingDots, AdBanner } from '@/components';
 import { wifiStyles as styles } from './wifiStyles';
 
 interface WiFiEditSettingsProps {
@@ -87,6 +87,8 @@ export function WiFiEditSettings({
                             placeholderTextColor={colors.textSecondary}
                         />
                     </View>
+
+                    <AdBanner />
 
                     <View style={styles.formGroup}>
                         <Text style={[typography.subheadline, { color: colors.textSecondary, marginBottom: 6 }]}>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -702,7 +702,9 @@
     "blockerDetected": "Ad blocker detected",
     "supportDeveloper": "Please disable your ad blocker to support the developer of this free app.",
     "rewardRequired": "Ad Required",
-    "watchAdToAccess": "Please watch the full ad to access this feature."
+    "watchAdToAccess": "Please watch the full ad to access this feature.",
+    "adblockNoticeTitle": "AdBlock Notice",
+    "adblockNoticeMessage": "Please make sure you are not using an ad blocker to enjoy all the features of this app."
   }
 }
 

--- a/src/i18n/id.json
+++ b/src/i18n/id.json
@@ -702,7 +702,9 @@
     "blockerDetected": "Pemblokir iklan terdeteksi",
     "supportDeveloper": "Nonaktifkan pemblokir iklan untuk mendukung pengembang aplikasi gratis ini.",
     "rewardRequired": "Iklan Diperlukan",
-    "watchAdToAccess": "Tonton iklan sampai selesai untuk mengakses fitur ini."
+    "watchAdToAccess": "Tonton iklan sampai selesai untuk mengakses fitur ini.",
+    "adblockNoticeTitle": "Pemberitahuan AdBlock",
+    "adblockNoticeMessage": "Pastikan Anda tidak menggunakan adblock untuk dapat menggunakan semua fitur dalam aplikasi ini secara maksimal."
   }
 }
 

--- a/src/services/sms.service.ts
+++ b/src/services/sms.service.ts
@@ -134,7 +134,7 @@ const MOCK_SMS_COUNT: SMSCount = {
 };
 
 // Global flag to enable mock mode for testing
-let useMockSMSData = true;
+let useMockSMSData = false;
 
 export function setMockSMSMode(enabled: boolean): void {
   useMockSMSData = enabled;

--- a/src/stores/auth.store.ts
+++ b/src/stores/auth.store.ts
@@ -183,9 +183,8 @@ export const useAuthStore = create<AuthState>((set, get) => ({
     setRelogging(true);
     set({ connectionError: null });
 
-    // Check if modem is reachable first (with 3 second timeout)
     console.log('[Auth] Checking modem reachability...');
-    const isReachable = await networkService.isModemReachable(credentials.modemIp, 3000);
+    const isReachable = await networkService.isModemReachable(credentials.modemIp, 7500);
 
     if (!isReachable) {
       console.log('[Auth] Modem not reachable at', credentials.modemIp);


### PR DESCRIPTION
- Implement rewarded ad requirements for Signal Finder, Change IP, and Band Selection applying
- Update SpeedtestModal to fetch and display real client ISP hostname, IP, and ISP using ipinfo.io
- Resolve missing 'earth' icon in AntDesign by using Ionicons and add icons for IP/host metadata
- Introduce startup alert in HomeScreen to prompt users to disable adblockers
- Localize adblock alert text in en.json and id.json