### PR TITLE
feat(theme): propagate accent color to traffic‑stats cards

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -40,7 +40,7 @@ export default ({ config }: ConfigContext): ExpoConfig => {
         ...config,
         name: isDev ? 'HM Mobile [DEV]' : 'Huawei Manager',
         slug: 'hm-mobile',
-        version: '1.1.26',
+        version: '1.1.27',
         orientation: 'portrait',
         icon: './assets/logo.png',
         userInterfaceStyle: 'automatic',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hm-mobile",
-  "version": "1.1.26",
+  "version": "1.1.27",
   "main": "index.js",
   "scripts": {
     "start": "expo start",

--- a/src/app/(tabs)/settings/index.tsx
+++ b/src/app/(tabs)/settings/index.tsx
@@ -11,7 +11,7 @@ import {
 import { useRouter } from 'expo-router';
 import Constants from 'expo-constants';
 import { MaterialIcons } from '@expo/vector-icons';
-import { useTheme } from '@/theme';
+import { useTheme, ACCENT_PRESETS } from '@/theme';
 import { useTranslation } from '@/i18n';
 import { SettingsSection, SettingsItem, SelectionModal, MeshGradientBackground, PageHeader, AnimatedScreen, ThemedSwitch, ThemedAlertHelper, BouncingDots, AdBanner } from '@/components';
 import { useThemeStore } from '@/stores/theme.store';
@@ -22,11 +22,12 @@ export default function SettingsIndex() {
     const router = useRouter();
     const { colors, typography } = useTheme();
     const { t } = useTranslation();
-    const { themeMode, setThemeMode, language, setLanguage, usageCardStyle, setUsageCardStyle } = useThemeStore();
+    const { themeMode, setThemeMode, language, setLanguage, usageCardStyle, setUsageCardStyle, accentColor, setAccentColor } = useThemeStore();
 
     const [showThemeModal, setShowThemeModal] = React.useState(false);
     const [showLanguageModal, setShowLanguageModal] = React.useState(false);
     const [showUsageModal, setShowUsageModal] = React.useState(false);
+    const [showAccentModal, setShowAccentModal] = React.useState(false);
     const [isSendingDebugLog, setIsSendingDebugLog] = React.useState(false);
 
     // Debug store
@@ -120,6 +121,24 @@ export default function SettingsIndex() {
                                 >
                                     <Text style={[styles.dropdownText, { color: colors.text }]}>
                                         {getThemeLabel(themeMode)}
+                                    </Text>
+                                    <MaterialIcons name="arrow-drop-down" size={20} color={colors.textSecondary} />
+                                </TouchableOpacity>
+                            }
+                        />
+
+                        <SettingsItem
+                            icon="palette"
+                            title={t('settings.accentColor')}
+                            onPress={() => setShowAccentModal(true)}
+                            rightElement={
+                                <TouchableOpacity
+                                    style={[styles.dropdownTrigger, { backgroundColor: colors.card, borderColor: colors.border }]}
+                                    onPress={() => setShowAccentModal(true)}
+                                >
+                                    <View style={[styles.accentPreview, { backgroundColor: colors.primary }]} />
+                                    <Text style={[styles.dropdownText, { color: colors.text }]}>
+                                        {(ACCENT_PRESETS[accentColor] || ACCENT_PRESETS.default).label}
                                     </Text>
                                     <MaterialIcons name="arrow-drop-down" size={20} color={colors.textSecondary} />
                                 </TouchableOpacity>
@@ -368,6 +387,21 @@ export default function SettingsIndex() {
                         }}
                         onClose={() => setShowUsageModal(false)}
                     />
+
+                    <SelectionModal
+                        visible={showAccentModal}
+                        title={t('settings.accentColor')}
+                        options={Object.entries(ACCENT_PRESETS).map(([key, preset]) => ({
+                            label: preset.label,
+                            value: key,
+                        }))}
+                        selectedValue={accentColor}
+                        onSelect={(val) => {
+                            setAccentColor(val);
+                            setShowAccentModal(false);
+                        }}
+                        onClose={() => setShowAccentModal(false)}
+                    />
                 </ScrollView>
             </MeshGradientBackground>
         </AnimatedScreen>
@@ -390,6 +424,11 @@ const styles = StyleSheet.create({
     dropdownText: {
         fontSize: 12,
         fontWeight: '600',
+    },
+    accentPreview: {
+        width: 14,
+        height: 14,
+        borderRadius: 7,
     },
     clearButton: {
         paddingVertical: 4,

--- a/src/components/CompactUsageCard.tsx
+++ b/src/components/CompactUsageCard.tsx
@@ -49,7 +49,7 @@ export function CompactUsageCard({ stats, dataLimit, style }: CompactUsageCardPr
     const { t } = useTranslation();
     const [activeTab, setActiveTab] = useState<TabType>('monthly');
 
-    const blueColor = '#3b82f6';
+    const blueColor = colors.primary;
     const greenColor = '#22c55e';
     const purpleColor = '#a855f7';
 
@@ -138,7 +138,7 @@ export function CompactUsageCard({ stats, dataLimit, style }: CompactUsageCardPr
                                 onPress={() => setActiveTab(tab)}
                                 style={[
                                     styles.tabItem,
-                                    activeTab === tab && { backgroundColor: isDark ? 'rgba(59, 130, 246, 0.3)' : 'rgba(59, 130, 246, 0.15)' }
+                                    activeTab === tab && { backgroundColor: isDark ? `${colors.primary}4D` : `${colors.primary}26` }
                                 ]}
                             >
                                 <Text

--- a/src/components/DailyUsageCard.tsx
+++ b/src/components/DailyUsageCard.tsx
@@ -39,7 +39,7 @@ export function DailyUsageCard({ usage, duration, style }: DailyUsageCardProps) 
     const hh = hours.toString().padStart(2, '0');
     const mm = minutes.toString().padStart(2, '0');
 
-    const blueColor = '#007AFF';
+    const blueColor = colors.primary;
 
     return (
         <Card style={[styles.container, style]}>

--- a/src/components/MonthlyComparisonCard.tsx
+++ b/src/components/MonthlyComparisonCard.tsx
@@ -74,7 +74,7 @@ export function MonthlyComparisonCard({
         }
     }, [totalDownload, totalUpload, monthDownload, monthUpload]);
 
-    const blueColor = '#3b82f6';
+    const blueColor = colors.primary;
     const grayColor = '#6b7280';
     const greenColor = '#22c55e';
     const redColor = '#ef4444';

--- a/src/components/UsageCard.tsx
+++ b/src/components/UsageCard.tsx
@@ -60,7 +60,7 @@ export function UsageCard({
 
     const badgeText = badge || (duration ? formatDuration(duration, durationUnits) : '');
 
-    const highlightColor = '#3b82f6';
+    const highlightColor = colors.primary;
 
     const getProgressColor = (pct: number): string => {
         if (pct >= 90) return '#ef4444';

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -497,7 +497,8 @@
     "fddOnly": "FDD Only",
     "bandsFound": "{{count}} BANDS FOUND",
     "deselectAll": "Deselect All",
-    "selectAll": "Select All"
+    "selectAll": "Select All",
+    "accentColor": "Accent Color"
   },
   "webViewLogin": {
     "title": "Modem Login",

--- a/src/i18n/id.json
+++ b/src/i18n/id.json
@@ -497,7 +497,8 @@
     "allBands": "Semua Frekuensi",
     "tddOnly": "Hanya TDD",
     "fddOnly": "Hanya FDD",
-    "bandsFound": "{{count}} DITEMUKAN"
+    "bandsFound": "{{count}} DITEMUKAN",
+    "accentColor": "Warna Aksen"
   },
   "webViewLogin": {
     "title": "Login Modem",

--- a/src/stores/theme.store.ts
+++ b/src/stores/theme.store.ts
@@ -7,12 +7,14 @@ type ThemeMode = 'light' | 'dark' | 'system';
 
 interface ThemeState {
   themeMode: ThemeMode;
+  accentColor: string;
   refreshInterval: number;
   language: string;
   isLanguageInitialized: boolean;
   badgesEnabled: boolean;
 
   setThemeMode: (mode: ThemeMode) => void;
+  setAccentColor: (color: string) => void;
   usageCardStyle: 'split' | 'compact';
   setUsageCardStyle: (style: 'split' | 'compact') => void;
   setRefreshInterval: (interval: number) => void;
@@ -25,6 +27,7 @@ export const useThemeStore = create<ThemeState>()(
   persist(
     (set, get) => ({
       themeMode: 'system',
+      accentColor: 'default',
       refreshInterval: 5000,
       language: 'en',
       isLanguageInitialized: false,
@@ -33,6 +36,7 @@ export const useThemeStore = create<ThemeState>()(
       setThemeMode: (mode) => {
         set({ themeMode: mode });
       },
+      setAccentColor: (color) => set({ accentColor: color }),
       usageCardStyle: 'split',
       setUsageCardStyle: (style) => set({ usageCardStyle: style }),
       setRefreshInterval: (interval) => set({ refreshInterval: interval }),

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,6 +1,25 @@
 import { useColorScheme } from 'react-native';
 import { useThemeStore } from '@/stores/theme.store';
 
+export const ACCENT_PRESETS: Record<string, { light: string; dark: string; label: string }> = {
+  default: { light: '#2563EB', dark: '#3B82F6', label: 'Blue' },
+  indigo: { light: '#4F46E5', dark: '#818CF8', label: 'Indigo' },
+  slate: { light: '#475569', dark: '#94A3B8', label: 'Slate' },
+  violet: { light: '#7C3AED', dark: '#A78BFA', label: 'Violet' },
+  purple: { light: '#9333EA', dark: '#C084FC', label: 'Purple' },
+  fuchsia: { light: '#C026D3', dark: '#E879F9', label: 'Fuchsia' },
+  pink: { light: '#DB2777', dark: '#F472B6', label: 'Pink' },
+  rose: { light: '#E11D48', dark: '#FB7185', label: 'Rose' },
+  red: { light: '#DC2626', dark: '#F87171', label: 'Red' },
+  orange: { light: '#EA580C', dark: '#FB923C', label: 'Orange' },
+  amber: { light: '#D97706', dark: '#FBBF24', label: 'Amber' },
+  lime: { light: '#65A30D', dark: '#A3E635', label: 'Lime' }, 
+  emerald: { light: '#059669', dark: '#34D399', label: 'Emerald' },
+  teal: { light: '#0D9488', dark: '#2DD4BF', label: 'Teal' },
+  cyan: { light: '#0891B2', dark: '#22D3EE', label: 'Cyan' },
+  sky: { light: '#0284C7', dark: '#38BDF8', label: 'Sky' },
+};
+
 export const Colors = {
   light: {
     primary: '#2563EB',
@@ -146,7 +165,7 @@ export const Typography = {
 
 export const useTheme = () => {
   const systemColorScheme = useColorScheme();
-  const { themeMode } = useThemeStore();
+  const { themeMode, accentColor } = useThemeStore();
 
   let isDark: boolean;
   if (themeMode === 'system') {
@@ -155,8 +174,14 @@ export const useTheme = () => {
     isDark = themeMode === 'dark';
   }
 
+  const baseColors = isDark ? { ...Colors.dark } : { ...Colors.light };
+
+  const accent = ACCENT_PRESETS[accentColor] || ACCENT_PRESETS.default;
+  baseColors.primary = isDark ? accent.dark : accent.light;
+  baseColors.shadow = `${baseColors.primary}1A`;
+
   return {
-    colors: isDark ? Colors.dark : Colors.light,
+    colors: baseColors,
     spacing: Spacing,
     borderRadius: BorderRadius,
     typography: Typography,
@@ -167,3 +192,4 @@ export const useTheme = () => {
 };
 
 export type Theme = ReturnType<typeof useTheme>;
+


### PR DESCRIPTION
- UsageCard: use colors.primary instead of hard‑coded blue
- CompactUsageCard: replace blueColor with colors.primary and update active tab background opacity
- MonthlyComparisonCard: replace blueColor with colors.primary
- DailyUsageCard: replace hard‑coded blue with colors.primary
- Expanded ACCENT_PRESETS with additional hue options