### PR TITLE
fix(modem): resolve multiple Huawei modem bugs and improve ad/IP alerts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ node_modules/
 # others
 notes.txt
 .agent/
+/reports
 
 # Expo
 .expo/

--- a/src/app/(tabs)/home.tsx
+++ b/src/app/(tabs)/home.tsx
@@ -112,14 +112,24 @@ export default function HomeScreen() {
     };
     loadLastClearedDate();
 
-    // Show warning about adblockers on startup
-    setTimeout(() => {
+    // Show warning about adblockers on startup with auto close
+    let timerDismiss: NodeJS.Timeout;
+    const timerShow = setTimeout(() => {
       ThemedAlertHelper.alert(
         t('ads.adblockNoticeTitle'),
         t('ads.adblockNoticeMessage'),
         [{ text: t('common.ok') }]
       );
-    }, 1500);
+
+      timerDismiss = setTimeout(() => {
+        ThemedAlertHelper.dismiss();
+      }, 4000); // Auto close after 4 seconds
+    }, 3000); // Delay of 3 seconds to show
+
+    return () => {
+      clearTimeout(timerShow);
+      if (timerDismiss) clearTimeout(timerDismiss);
+    };
   }, []);
 
   useEffect(() => {
@@ -194,7 +204,7 @@ export default function HomeScreen() {
       setIsRefreshing(true);
 
       const [signal, network, traffic, status, wan, dataStatus] = await Promise.all([
-        service.getSignalInfo(),
+        service.getSignalInfo().catch(() => null),
         service.getNetworkInfo(),
         service.getTrafficStats(),
         service.getModemStatus(),
@@ -246,12 +256,19 @@ export default function HomeScreen() {
           }
         );
 
-        checkIPChangeNotification(traffic.currentConnectTime || 0, {
+        const ipChanged = await checkIPChangeNotification(traffic.currentConnectTime || 0, {
           title: t('notifications.ipChangeTitle'),
           body: (duration) => duration === '0'
             ? t('notifications.ipChangeBodyJustNow')
             : t('notifications.ipChangeBody', { duration }),
         });
+
+        if (ipChanged) {
+          ThemedAlertHelper.alert(
+            t('notifications.ipChangeTitle'),
+            t('notifications.ipChangeBodyAlert') || 'IP Address has changed successfully.'
+          );
+        }
       }
 
       const isDataEmpty = !signal?.rsrp && !signal?.rssi && !status?.connectionStatus;
@@ -271,7 +288,7 @@ export default function HomeScreen() {
       const isSessionError = errorMessage.includes('125003') ||
         errorMessage.includes('session') ||
         errorMessage.includes('login') ||
-        !signalInfo;
+        !modemStatus;
 
 
       if (isSessionError && credentials && reloginAttempts < 3 && !showReloginWebView) {
@@ -288,7 +305,7 @@ export default function HomeScreen() {
   const loadDataSilent = async (service: ModemService) => {
     try {
       const [signal, network, traffic, status, wan, dataStatus] = await Promise.all([
-        service.getSignalInfo(),
+        service.getSignalInfo().catch(() => null),
         service.getNetworkInfo(),
         service.getTrafficStats(),
         service.getModemStatus(),
@@ -318,7 +335,7 @@ export default function HomeScreen() {
       const errorMessage = error?.message || '';
       const isSessionError = errorMessage.includes('125003') ||
         errorMessage.includes('session') ||
-        !signalInfo;
+        !modemStatus;
 
 
       if (isSessionError && credentials && reloginAttempts < 3 && !showReloginWebView) {

--- a/src/app/(tabs)/settings/mobile-network.tsx
+++ b/src/app/(tabs)/settings/mobile-network.tsx
@@ -191,8 +191,12 @@ export default function MobileNetworkSettingsScreen() {
             if (changed) {
                 showInterstitial(() => {});
             }
-        } catch (error) {
-            ThemedAlertHelper.alert(t('common.error'), t('alerts.failedChangeNetwork'));
+        } catch (error: any) {
+            let errorMessage = t('alerts.failedChangeNetwork');
+            if (error?.huaweiErrorCode === '100003') {
+                errorMessage = t('alerts.networkModeNotSupported') || 'Preferred network mode selection is not supported on this modem.';
+            }
+            ThemedAlertHelper.alert(t('common.error'), errorMessage);
         } finally {
             setIsChangingNetwork(false);
         }

--- a/src/app/(tabs)/wifi.tsx
+++ b/src/app/(tabs)/wifi.tsx
@@ -453,8 +453,12 @@ export default function WiFiScreen() {
       await wifiService.changeDeviceName(deviceId, newName);
       ThemedAlertHelper.alert(t('common.success'), t('wifi.deviceNameSaved'));
       handleRefresh();
-    } catch (error) {
-      ThemedAlertHelper.alert(t('common.error'), t('wifi.failedSaveDeviceName'));
+    } catch (error: any) {
+      let errorMessage = t('wifi.failedSaveDeviceName');
+      if (error?.huaweiErrorCode === '100002') {
+        errorMessage = t('alerts.renameNotSupported') || 'Changing device name is not supported on this modem model.';
+      }
+      ThemedAlertHelper.alert(t('common.error'), errorMessage);
       throw error;
     }
   };

--- a/src/components/BandSelectionModal.tsx
+++ b/src/components/BandSelectionModal.tsx
@@ -152,11 +152,14 @@ export function BandSelectionModal({
                         const lteBandHex = lteBandValue.toString(16).toUpperCase();
 
                         await modemService.setBandSettings('3FFFFFFF', lteBandHex);
-                        ThemedAlertHelper.alert(t('common.success'), t('settings.bandSettingsSaved'));
+                         ThemedAlertHelper.alert(t('common.success'), t('settings.bandSettingsSaved'));
                         onClose();
                         onSaved?.();
                     } catch (error: any) {
-                        const errorMessage = error?.message || t('alerts.failedSaveBands');
+                        let errorMessage = error?.message || t('alerts.failedSaveBands');
+                        if (error?.huaweiErrorCode === '100003') {
+                            errorMessage = t('alerts.bandNotSupported') || 'LTE Band selection is not supported on this modem model.';
+                        }
                         ThemedAlertHelper.alert(t('common.error'), errorMessage);
                     } finally {
                         setIsSaving(false);

--- a/src/components/SignalPointingModal.tsx
+++ b/src/components/SignalPointingModal.tsx
@@ -164,6 +164,7 @@ export function SignalPointingModal({ visible, onClose }: SignalPointingModalPro
     const [bestPci, setBestPci] = useState<string | null>(null);
     const [soundEnabled, setSoundEnabled] = useState(false);
     const [isLoading, setIsLoading] = useState(true);
+    const [signalUnsupported, setSignalUnsupported] = useState(false);
     const [fetchTime, setFetchTime] = useState<number | null>(null);
     const [signalHistory, setSignalHistory] = useState<number[]>([]);
 
@@ -208,6 +209,7 @@ export function SignalPointingModal({ visible, onClose }: SignalPointingModalPro
             setSignalInfo(null);
             setBestRsrp(null);
             setIsLoading(true);
+            setSignalUnsupported(false);
             setFetchTime(null);
             setSignalHistory([]);
             previousValueRef.current = null;
@@ -248,8 +250,18 @@ export function SignalPointingModal({ visible, onClose }: SignalPointingModalPro
                 }
                 previousValueRef.current = currentValue;
             }
-        } catch (error) {
+        } catch (error: any) {
+            setIsLoading(false);
             setFetchTime(Date.now() - startTime);
+            // If modem returned a Huawei error code (e.g. 100003 = endpoint not supported),
+            // stop polling and show a clear unsupported message instead of retrying endlessly.
+            if (error?.huaweiErrorCode) {
+                setSignalUnsupported(true);
+                if (intervalRef.current) {
+                    clearInterval(intervalRef.current);
+                    intervalRef.current = null;
+                }
+            }
         }
     }, [modemService]);
 
@@ -326,6 +338,20 @@ export function SignalPointingModal({ visible, onClose }: SignalPointingModalPro
                 contentContainerStyle={{ paddingBottom: 40 }}
                 showsVerticalScrollIndicator={false}
             >
+                {signalUnsupported ? (
+                    <Card style={{ marginTop: spacing.md, borderColor: colors.warning, borderWidth: 1.5 }}>
+                        <View style={{ alignItems: 'center', paddingVertical: spacing.md }}>
+                            <MaterialIcons name="signal-wifi-off" size={48} color={colors.warning} />
+                            <Text style={[typography.headline, { color: colors.text, textAlign: 'center', marginTop: 12 }]}>
+                                {t('home.noSignalData')}
+                            </Text>
+                            <Text style={[typography.body, { color: colors.textSecondary, textAlign: 'center', marginTop: 8, lineHeight: 22 }]}>
+                                {t('home.noSignalMessage')}
+                            </Text>
+                        </View>
+                    </Card>
+                ) : (
+                    <>
                 <View style={[styles.metricToggle, { backgroundColor: isDark ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.05)' }]}>
                     <TouchableOpacity
                         style={[styles.metricButton, signalMetric === 'rsrp' && { backgroundColor: colors.primary }]}
@@ -544,6 +570,8 @@ export function SignalPointingModal({ visible, onClose }: SignalPointingModalPro
                 <View style={{ paddingHorizontal: 16, marginTop: 16, marginBottom: 16 }}>
                     <AdNative />
                 </View>
+                    </>
+                )}
             </ScrollView>
 
             <SelectionModal

--- a/src/components/ThemedAlert.tsx
+++ b/src/components/ThemedAlert.tsx
@@ -148,6 +148,16 @@ export const ThemedAlertHelper = {
             });
         }
     },
+    dismiss: () => {
+        if (alertListener) {
+            alertListener({
+                visible: false,
+                title: '',
+                message: '',
+                buttons: [],
+            });
+        }
+    },
 };
 
 const { width } = Dimensions.get('window');

--- a/src/hooks/useModemData.ts
+++ b/src/hooks/useModemData.ts
@@ -73,6 +73,7 @@ export function useModemData({ t, durationUnits }: UseModemDataOptions): UseMode
     const {
         signalInfo,
         monthlySettings,
+        modemStatus,
         setSignalInfo,
         setNetworkInfo,
         setTrafficStats,
@@ -173,7 +174,7 @@ export function useModemData({ t, durationUnits }: UseModemDataOptions): UseMode
             setIsRefreshing(true);
 
             const [signal, network, traffic, status, wan, dataStatus] = await Promise.all([
-                service.getSignalInfo(),
+                service.getSignalInfo().catch(() => null),
                 service.getNetworkInfo(),
                 service.getTrafficStats(),
                 service.getModemStatus(),
@@ -225,12 +226,19 @@ export function useModemData({ t, durationUnits }: UseModemDataOptions): UseMode
                     }
                 );
 
-                checkIPChangeNotification(traffic.currentConnectTime || 0, {
+                const ipChanged = await checkIPChangeNotification(traffic.currentConnectTime || 0, {
                     title: t('notifications.ipChangeTitle'),
                     body: (duration) => duration === '0'
                         ? t('notifications.ipChangeBodyJustNow')
                         : t('notifications.ipChangeBody', { duration }),
                 });
+
+                if (ipChanged) {
+                    ThemedAlertHelper.alert(
+                        t('notifications.ipChangeTitle'),
+                        t('notifications.ipChangeBodyAlert') || 'IP Address has changed successfully.'
+                    );
+                }
             }
 
             const isDataEmpty = !signal?.rsrp && !signal?.rssi && !status?.connectionStatus;
@@ -250,7 +258,7 @@ export function useModemData({ t, durationUnits }: UseModemDataOptions): UseMode
             const isSessionError = errorMessage.includes('125003') ||
                 errorMessage.includes('session') ||
                 errorMessage.includes('login') ||
-                !signalInfo;
+                !modemStatus;
 
             if (isSessionError && credentials && reloginAttempts < 3 && !showReloginWebView) {
                 requestRelogin();
@@ -266,7 +274,7 @@ export function useModemData({ t, durationUnits }: UseModemDataOptions): UseMode
     const loadDataSilent = async (service: ModemService) => {
         try {
             const [signal, network, traffic, status, wan, dataStatus] = await Promise.all([
-                service.getSignalInfo(),
+                service.getSignalInfo().catch(() => null),
                 service.getNetworkInfo(),
                 service.getTrafficStats(),
                 service.getModemStatus(),
@@ -295,7 +303,7 @@ export function useModemData({ t, durationUnits }: UseModemDataOptions): UseMode
             const errorMessage = error?.message || '';
             const isSessionError = errorMessage.includes('125003') ||
                 errorMessage.includes('session') ||
-                !signalInfo;
+                !modemStatus;
 
             if (isSessionError && credentials && reloginAttempts < 3 && !showReloginWebView) {
                 requestRelogin();

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -84,7 +84,10 @@
     "silentLoginFailed": "Auto-login failed after 3 attempts. Please log in manually.",
     "modemNotResponding": "Modem not responding",
     "failedSaveModemSettings": "Failed to save modem settings",
-    "failedSaveGuestWifi": "Failed to save guest WiFi settings"
+    "failedSaveGuestWifi": "Failed to save guest WiFi settings",
+    "bandNotSupported": "LTE Band selection is not supported on this modem model (error 100003).",
+    "renameNotSupported": "Changing device name is not supported on this modem model (error 100002).",
+    "networkModeNotSupported": "Preferred network mode selection is not supported on this modem model (error 100003)."
   },
   "tabs": {
     "home": "Home",
@@ -173,6 +176,8 @@
     "confirmEnableData": "Are you sure you want to enable mobile data?",
     "confirmDisableData": "Are you sure you want to disable mobile data?",
     "noSignalAvailable": "No signal data available",
+    "noSignalData": "Signal Detail Not Supported",
+    "noSignalMessage": "This modem model does not support the detailed signal API (\u002Fapi\u002Fdevice\u002Fsignal). Signal metrics like RSRP, RSRQ, SINR are not available for this device.",
     "checkLogin": "Please check if you're logged in to the modem",
     "width": "Width",
     "plmnScanHint": "Triggers PLMN scan to get a new IP address",
@@ -680,6 +685,7 @@
     "ipChangeTitle": "IP Address Changed",
     "ipChangeBody": "IP changed after {{duration}} session",
     "ipChangeBodyJustNow": "IP just changed",
+    "ipChangeBodyAlert": "IP Address has changed successfully.",
     "minutesAgo": "{{minutes}} minutes ago",
     "hoursAgo": "{{hours}} hours ago",
     "justNow": "Just now",
@@ -706,7 +712,8 @@
     "watchAdToAccess": "Please watch the full ad to access this feature.",
     "adblockNoticeTitle": "AdBlock Notice",
     "adblockNoticeMessage": "Please make sure you are not using an ad blocker to enjoy all the features of this app.",
-    "failedToLoad": "Failed to load advertisement. Please check your internet connection or disable your ad blocker."
+    "failedToLoad": "Failed to load advertisement. Please check your internet connection or disable your ad blocker.",
+    "adServerConnectionFailed": "Failed to connect to ad server. If you are using an ad blocker or custom DNS (like AdGuard), please disable it to load ads and support the app."
   }
 }
 

--- a/src/i18n/id.json
+++ b/src/i18n/id.json
@@ -84,7 +84,10 @@
     "silentLoginFailed": "Login otomatis gagal setelah 3 percobaan. Silakan login manual.",
     "modemNotResponding": "Modem tidak merespons",
     "failedSaveModemSettings": "Gagal menyimpan pengaturan modem",
-    "failedSaveGuestWifi": "Gagal menyimpan pengaturan WiFi Tamu"
+    "failedSaveGuestWifi": "Gagal menyimpan pengaturan WiFi Tamu",
+    "bandNotSupported": "Pemilihan LTE Band tidak didukung oleh model modem ini (error 100003).",
+    "renameNotSupported": "Mengubah nama perangkat tidak didukung oleh model modem ini (error 100002).",
+    "networkModeNotSupported": "Pemilihan tipe jaringan yang disukai tidak didukung oleh model modem ini (error 100003)."
   },
   "tabs": {
     "home": "Beranda",
@@ -173,6 +176,8 @@
     "confirmEnableData": "Yakin ingin mengaktifkan data seluler?",
     "confirmDisableData": "Yakin ingin menonaktifkan data seluler?",
     "noSignalAvailable": "Tidak ada data sinyal",
+    "noSignalData": "Detail Sinyal Tidak Didukung",
+    "noSignalMessage": "Model modem ini tidak mendukung API sinyal detail (/api/device/signal). Metrik sinyal seperti RSRP, RSRQ, SINR tidak tersedia untuk perangkat ini.",
     "checkLogin": "Periksa apakah Anda sudah login ke modem",
     "width": "Lebar",
     "plmnScanHint": "Memicu pemindaian PLMN untuk mendapatkan alamat IP baru",
@@ -680,6 +685,7 @@
     "ipChangeTitle": "IP Address Berubah",
     "ipChangeBody": "IP berubah setelah {{duration}} sesi",
     "ipChangeBodyJustNow": "IP baru saja berubah",
+    "ipChangeBodyAlert": "Alamat IP berhasil diubah.",
     "minutesAgo": "{{minutes}} menit yang lalu",
     "hoursAgo": "{{hours}} jam yang lalu",
     "justNow": "Baru saja",
@@ -706,7 +712,8 @@
     "watchAdToAccess": "Tonton iklan sampai selesai untuk mengakses fitur ini.",
     "adblockNoticeTitle": "Pemberitahuan AdBlock",
     "adblockNoticeMessage": "Pastikan Anda tidak menggunakan adblock untuk dapat menggunakan semua fitur dalam aplikasi ini secara maksimal.",
-    "failedToLoad": "Gagal memuat iklan. Silakan periksa koneksi internet Anda atau nonaktifkan pemblokir iklan."
+    "failedToLoad": "Gagal memuat iklan. Silakan periksa koneksi internet Anda atau nonaktifkan pemblokir iklan.",
+    "adServerConnectionFailed": "Gagal terhubung ke server iklan. Jika Anda menggunakan pemblokir iklan (ad blocker) atau DNS kustom (seperti AdGuard), harap nonaktifkan untuk memuat iklan dan mendukung aplikasi."
   }
 }
 

--- a/src/services/ad.service.ts
+++ b/src/services/ad.service.ts
@@ -58,6 +58,22 @@ let isInterstitialLoading = false;
 let isRewardedLoading = false;
 let isAppOpenLoading = false;
 
+let hasShownAdblockAlert = false;
+
+function handleAdError(error: any) {
+    if (!error) return;
+    const errMsg = error?.message || String(error);
+    if (errMsg.includes('doubleclick') || errMsg.includes('ad server') || errMsg.includes('Failed to connect')) {
+        if (!hasShownAdblockAlert) {
+            hasShownAdblockAlert = true;
+            ThemedAlertHelper.alert(
+                getTranslation('ads.blockerDetected') || 'Ad blocker detected',
+                getTranslation('ads.adServerConnectionFailed') || 'Failed to connect to ad server. If you are using an ad blocker or custom DNS (like AdGuard), please disable it to load ads and support the app.'
+            );
+        }
+    }
+}
+
 /**
  * Initializes AdMob SDK globally and preloads the first ads.
  * This should be called early at app startup (e.g. in RootLayout).
@@ -140,6 +156,7 @@ export function preloadRewarded(): void {
         preloadedRewarded = null;
         cleanup();
         console.warn('❌ Failed to preload Rewarded ad:', error);
+        handleAdError(error);
     });
 
     function cleanup() {
@@ -237,8 +254,8 @@ export function showInterstitial(onDone: () => void): void {
 export function showRewarded(onRewarded: () => void, onSkipped: () => void): void {
     if (!isInitialized) {
         initAdMob();
-        // Warn the user that the ad failed to load rather than claiming they skipped it
-        showLoadErrorAlert();
+        // Fallback: Proceed silently if AdMob is not initialized
+        onRewarded();
         return;
     }
 
@@ -266,7 +283,8 @@ export function showRewarded(onRewarded: () => void, onSkipped: () => void): voi
             console.error('Failed to show preloaded rewarded ad:', err);
             unsubEarned();
             unsubClosed();
-            showLoadErrorAlert();
+            handleAdError(err);
+            onRewarded(); // Fallback: Proceed silently on show error
             preloadRewarded();
         });
     } else {
@@ -280,7 +298,7 @@ export function showRewarded(onRewarded: () => void, onSkipped: () => void): voi
             if (!completed) {
                 completed = true;
                 cleanup();
-                showLoadErrorAlert();
+                onRewarded(); // Fallback: Proceed silently on timeout
                 preloadRewarded();
             }
         }, 8000); // 8-second timeout for rewarded video
@@ -289,9 +307,10 @@ export function showRewarded(onRewarded: () => void, onSkipped: () => void): voi
             if (!completed) {
                 completed = true;
                 clearTimeout(timer);
-                ad.show().catch(() => {
+                ad.show().catch((err) => {
                     cleanup();
-                    showLoadErrorAlert();
+                    handleAdError(err);
+                    onRewarded(); // Fallback: Proceed silently on show error
                     preloadRewarded();
                 });
             }
@@ -311,12 +330,13 @@ export function showRewarded(onRewarded: () => void, onSkipped: () => void): voi
             preloadRewarded();
         });
 
-        const unsubError = ad.addAdEventListener(AdEventType.ERROR, () => {
+        const unsubError = ad.addAdEventListener(AdEventType.ERROR, (error) => {
             if (!completed) {
                 completed = true;
                 clearTimeout(timer);
                 cleanup();
-                showLoadErrorAlert();
+                handleAdError(error);
+                onRewarded(); // Fallback: Proceed silently on load error
                 preloadRewarded();
             }
         });

--- a/src/services/modem.service.ts
+++ b/src/services/modem.service.ts
@@ -64,6 +64,15 @@ export class ModemService {
   async getSignalInfo(): Promise<SignalInfo> {
     try {
       const response = await this.apiClient.get('/api/device/signal');
+
+      // Some modem models return an error XML instead of signal data (e.g. Huawei L02)
+      const errorCode = parseXMLValue(response, 'code');
+      if (errorCode) {
+        const err = new Error(`Signal endpoint not supported (error code ${errorCode})`) as any;
+        err.huaweiErrorCode = errorCode;
+        throw err;
+      }
+
       const lteBandwidth = parseXMLValue(response, 'lte_bandwidth');
 
       return {
@@ -92,6 +101,15 @@ export class ModemService {
   async getSignalInfoFast(): Promise<SignalInfo> {
     try {
       const response = await this.apiClient.getFast('/api/device/signal');
+
+      // Some modem models return an error XML instead of signal data (e.g. Huawei L02)
+      const errorCode = parseXMLValue(response, 'code');
+      if (errorCode) {
+        const err = new Error(`Signal endpoint not supported (error code ${errorCode})`) as any;
+        err.huaweiErrorCode = errorCode;
+        throw err;
+      }
+
       const lteBandwidth = parseXMLValue(response, 'lte_bandwidth');
 
       return {
@@ -269,11 +287,31 @@ export class ModemService {
         return isNaN(parsed) ? 0 : parsed;
       };
 
+      let wanIPAddress = parseXMLValue(response, 'WanIPAddress') || parseXMLValue(response, 'WanIpAddress') || '';
+      let primaryDns = parseXMLValue(response, 'PrimaryDNS') || parseXMLValue(response, 'PrimaryDns') || '';
+      let secondaryDns = parseXMLValue(response, 'SecondaryDNS') || parseXMLValue(response, 'SecondaryDns') || '';
+
+      // Fallback for modems (e.g. E3276) where WAN IP is not returned by /api/device/information
+      if (!wanIPAddress) {
+        try {
+          const statusResponse = await this.apiClient.get('/api/monitoring/status');
+          wanIPAddress = parseXMLValue(statusResponse, 'WanIPAddress') || parseXMLValue(statusResponse, 'WanIpAddress') || '';
+          if (!primaryDns) {
+            primaryDns = parseXMLValue(statusResponse, 'PrimaryDns') || parseXMLValue(statusResponse, 'PrimaryDNS') || '';
+          }
+          if (!secondaryDns) {
+            secondaryDns = parseXMLValue(statusResponse, 'SecondaryDns') || parseXMLValue(statusResponse, 'SecondaryDNS') || '';
+          }
+        } catch (fallbackError) {
+          console.error('Error getting fallback WAN IP from status:', fallbackError);
+        }
+      }
+
       return {
-        wanIPAddress: parseXMLValue(response, 'WanIPAddress') || parseXMLValue(response, 'WanIpAddress') || '',
+        wanIPAddress,
         uptime: safeParseInt(parseXMLValue(response, 'Uptime')),
-        primaryDns: parseXMLValue(response, 'PrimaryDNS') || '',
-        secondaryDns: parseXMLValue(response, 'SecondaryDNS') || '',
+        primaryDns,
+        secondaryDns,
       };
     } catch (error) {
       console.error('Error getting WAN info:', error);
@@ -402,7 +440,15 @@ export class ModemService {
           <LTEBand>7FFFFFFFFFFFFFFF</LTEBand>
         </request>`;
 
-      await this.apiClient.post('/api/net/net-mode', data);
+      const response = await this.apiClient.post('/api/net/net-mode', data);
+
+      const errorCode = parseXMLValue(response, 'code');
+      if (errorCode && errorCode !== '0') {
+        const err = new Error(`Failed to set network mode: error ${errorCode}`) as any;
+        err.huaweiErrorCode = errorCode;
+        throw err;
+      }
+
       return true;
     } catch (error) {
       console.error('Error setting network mode:', error);
@@ -430,6 +476,14 @@ export class ModemService {
   async setBandSettings(networkBand: string, lteBand: string): Promise<boolean> {
     try {
       const currentModeResponse = await this.apiClient.get('/api/net/net-mode');
+
+      const errorCodeGet = parseXMLValue(currentModeResponse, 'code');
+      if (errorCodeGet && errorCodeGet !== '0') {
+        const err = new Error(`Failed to get net mode: error ${errorCodeGet}`) as any;
+        err.huaweiErrorCode = errorCodeGet;
+        throw err;
+      }
+
       const currentMode = parseXMLValue(currentModeResponse, 'NetworkMode') || '00';
 
       const data = `<?xml version="1.0" encoding="UTF-8"?>
@@ -439,7 +493,15 @@ export class ModemService {
           <LTEBand>${lteBand}</LTEBand>
         </request>`;
 
-      await this.apiClient.post('/api/net/net-mode', data);
+      const response = await this.apiClient.post('/api/net/net-mode', data);
+
+      const errorCodePost = parseXMLValue(response, 'code');
+      if (errorCodePost && errorCodePost !== '0') {
+        const err = new Error(`Failed to set band settings: error ${errorCodePost}`) as any;
+        err.huaweiErrorCode = errorCodePost;
+        throw err;
+      }
+
       return true;
     } catch (error) {
       console.error('Error setting band settings:', error);

--- a/src/services/notification.service.ts
+++ b/src/services/notification.service.ts
@@ -290,9 +290,9 @@ export async function getLastIpChangeTime(): Promise<number | null> {
 export async function checkIPChangeNotification(
     currentSessionDuration: number,
     translations: { title: string; body: (timeAgo: string) => string }
-): Promise<void> {
+): Promise<boolean> {
     const settings = await getNotificationSettings();
-    if (!settings.ipChangeEnabled) return;
+    if (!settings.ipChangeEnabled) return false;
 
     const now = Date.now();
     if (now - lastIpChangeNotifyTimestamp < NOTIFICATION_COOLDOWN_MS) {
@@ -300,11 +300,12 @@ export async function checkIPChangeNotification(
             LAST_SESSION_DURATION_KEY,
             currentSessionDuration.toString()
         );
-        return;
+        return false;
     }
 
     const lastDuration = await AsyncStorage.getItem(LAST_SESSION_DURATION_KEY);
     const previousDuration = lastDuration ? parseInt(lastDuration, 10) : 0;
+    let ipChanged = false;
 
     if (currentSessionDuration < previousDuration && previousDuration > 60) {
         lastIpChangeNotifyTimestamp = now;
@@ -328,12 +329,15 @@ export async function checkIPChangeNotification(
             translations.body(durationText),
             'ip-change'
         );
+        ipChanged = true;
     }
 
     await AsyncStorage.setItem(
         LAST_SESSION_DURATION_KEY,
         currentSessionDuration.toString()
     );
+
+    return ipChanged;
 }
 
 // ============================================================================

--- a/src/services/wifi.service.ts
+++ b/src/services/wifi.service.ts
@@ -40,8 +40,12 @@ export class WiFiService {
         const hostInfoResponse = await this.apiClient.get('/api/system/HostInfo');
         let hostInfoList: any[] = [];
 
-        if (typeof hostInfoResponse === 'string') {
-          hostInfoList = JSON.parse(hostInfoResponse);
+        if (typeof hostInfoResponse === 'string' && !hostInfoResponse.includes('<error>')) {
+          try {
+            hostInfoList = JSON.parse(hostInfoResponse);
+          } catch (e) {
+            // Ignore parse errors
+          }
         } else if (Array.isArray(hostInfoResponse)) {
           hostInfoList = hostInfoResponse;
         }
@@ -903,7 +907,9 @@ ${guestPassword ? `<WifiWpapsk>${guestPassword}</WifiWpapsk>` : ''}
 
       if (response.includes('<error>')) {
         const errorCode = response.match(/<code>(\d+)<\/code>/)?.[1];
-        throw new Error(`Failed to change device name: error ${errorCode}`);
+        const error = new Error(`Failed to change device name: error ${errorCode}`) as any;
+        error.huaweiErrorCode = errorCode;
+        throw error;
       }
 
       return true;


### PR DESCRIPTION
- Implement fallback WAN IP retrieval from status endpoint for Hilink modems
- Propagate XML errors and handle unsupported features with custom UI alerts
- Catch signal info errors individually to prevent UI loading blocks
- Show alert on AdMob server connection failures advising to disable ad blockers
- Automatically dismiss startup Adblock Notice after 4 seconds
- Display on-screen alert when modem IP address changes in the foreground
- Fix reference error in useModemData.ts by destructuring modemStatus

Closes #129
Closes #124
Closes #122