### PR TITLE
feat(ad): implement custom bottom sheet modal for adblock warnings

### DIFF
--- a/src/app/(tabs)/home.tsx
+++ b/src/app/(tabs)/home.tsx
@@ -111,25 +111,6 @@ export default function HomeScreen() {
       }
     };
     loadLastClearedDate();
-
-    // Show warning about adblockers on startup with auto close
-    let timerDismiss: NodeJS.Timeout;
-    const timerShow = setTimeout(() => {
-      ThemedAlertHelper.alert(
-        t('ads.adblockNoticeTitle'),
-        t('ads.adblockNoticeMessage'),
-        [{ text: t('common.ok') }]
-      );
-
-      timerDismiss = setTimeout(() => {
-        ThemedAlertHelper.dismiss();
-      }, 4000); // Auto close after 4 seconds
-    }, 3000); // Delay of 3 seconds to show
-
-    return () => {
-      clearTimeout(timerShow);
-      if (timerDismiss) clearTimeout(timerDismiss);
-    };
   }, []);
 
   useEffect(() => {

--- a/src/app/(tabs)/settings/system.tsx
+++ b/src/app/(tabs)/settings/system.tsx
@@ -16,7 +16,7 @@ import { useAuthStore } from '@/stores/auth.store';
 import { useThemeStore } from '@/stores/theme.store';
 import { ModemService } from '@/services/modem.service';
 import { useTranslation } from '@/i18n';
-import { ThemedAlertHelper, Button, SettingsSection, SettingsItem, MeshGradientBackground, PageHeader, ThemedSwitch, BouncingDots, AnimatedScreen, AdNative } from '@/components';
+import { ThemedAlertHelper, Button, SettingsSection, SettingsItem, MeshGradientBackground, PageHeader, ThemedSwitch, BouncingDots, AnimatedScreen, AdNative, PageSheetModal } from '@/components';
 import { showInterstitial } from '@/services/ad.service';
 
 const TIMEZONES = [
@@ -346,36 +346,28 @@ export default function SystemSettingsScreen() {
                     </SettingsSection>
 
                     {/* Timezone Modal */}
-                    <Modal
+                    <PageSheetModal
                         visible={showTimezoneModal}
-                        animationType="slide"
-                        presentationStyle="pageSheet"
-                        onRequestClose={() => setShowTimezoneModal(false)}
+                        onClose={() => setShowTimezoneModal(false)}
+                        title={t('timeSettings.timeZone')}
+                        cancelText={t('common.cancel') || 'Cancel'}
                     >
-                        <View style={[styles.modalContainer, { backgroundColor: colors.background }]}>
-                            <View style={[styles.modalHeader, { borderBottomColor: colors.border }]}>
-                                <Text style={[typography.headline, { color: colors.text }]}>{t('timeSettings.timeZone')}</Text>
-                                <TouchableOpacity onPress={() => setShowTimezoneModal(false)}>
-                                    <Text style={{ color: colors.primary, fontSize: 17 }}>{t('common.done')}</Text>
+                        <ScrollView style={{ flex: 1, paddingHorizontal: 16, marginTop: 8 }}>
+                            {TIMEZONES.map((tz) => (
+                                <TouchableOpacity
+                                    key={tz}
+                                    style={[
+                                        styles.modalItem,
+                                        { borderBottomColor: colors.border, borderBottomWidth: StyleSheet.hairlineWidth }
+                                    ]}
+                                    onPress={() => handleTimezoneChange(tz)}
+                                >
+                                    <Text style={{ color: timezone === tz ? colors.primary : colors.text, fontSize: 16 }}>{tz}</Text>
+                                    {timezone === tz && <MaterialIcons name="check" size={20} color={colors.primary} />}
                                 </TouchableOpacity>
-                            </View>
-                            <ScrollView>
-                                {TIMEZONES.map((tz, index) => (
-                                    <TouchableOpacity
-                                        key={tz}
-                                        style={[
-                                            styles.modalItem,
-                                            { borderBottomColor: colors.border, borderBottomWidth: StyleSheet.hairlineWidth }
-                                        ]}
-                                        onPress={() => handleTimezoneChange(tz)}
-                                    >
-                                        <Text style={{ color: timezone === tz ? colors.primary : colors.text, fontSize: 16 }}>{tz}</Text>
-                                        {timezone === tz && <MaterialIcons name="check" size={20} color={colors.primary} />}
-                                    </TouchableOpacity>
-                                ))}
-                            </ScrollView>
-                        </View>
-                    </Modal>
+                            ))}
+                        </ScrollView>
+                    </PageSheetModal>
 
                     <View style={{ paddingHorizontal: 16, marginTop: 8 }}>
                         <AdNative />

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -10,7 +10,7 @@ import * as SplashScreen from 'expo-splash-screen';
 import { useAuthStore } from '@/stores/auth.store';
 import { useThemeStore } from '@/stores/theme.store';
 import { useTheme } from '@/theme';
-import { ThemedAlert, setAlertListener, ThemedAlertHelper, AnimatedSplashScreen } from '@/components';
+import { ThemedAlert, setAlertListener, ThemedAlertHelper, AnimatedSplashScreen, AdblockAlertModal } from '@/components';
 import { useTranslation } from '@/i18n';
 import { startRealtimeWidgetUpdates, stopRealtimeWidgetUpdates } from '@/widget';
 import { isSessionLikelyValid } from '@/utils/storage';
@@ -386,6 +386,8 @@ export default function RootLayout() {
                     buttons={alertState.buttons}
                     onDismiss={dismissAlert}
                 />
+
+                <AdblockAlertModal />
             </KeyboardProvider>
         </GestureHandlerRootView>
     );

--- a/src/components/AdBanner.tsx
+++ b/src/components/AdBanner.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { View, Text, StyleSheet, Image, ActivityIndicator } from 'react-native';
+import { View, Text, StyleSheet, Image } from 'react-native';
 import mobileAds, {
     BannerAd,
     BannerAdSize,
@@ -15,6 +15,8 @@ import Constants from 'expo-constants';
 import { MaterialIcons } from '@expo/vector-icons';
 import { useTheme } from '@/theme';
 import { useTranslation } from '@/i18n';
+import { BouncingDots } from './ModernLoading';
+import { AdblockAlertHelper } from './AdblockAlertModal';
 
 const BANNER_AD_UNIT_ID = Constants.expoConfig?.extra?.admobBannerUnitId || TestIds.BANNER;
 const NATIVE_AD_UNIT_ID = Constants.expoConfig?.extra?.admobNativeAdvancedUnitId || TestIds.NATIVE;
@@ -46,26 +48,37 @@ function initializeAds(): Promise<void> {
     return adsInitPromise;
 }
 
+function triggerAdblockAlert(error: any) {
+    if (!error) return;
+    const errMsg = error?.message || String(error);
+    if (errMsg.includes('doubleclick') || errMsg.includes('ad server') || errMsg.includes('Failed to connect') || errMsg.includes('Timeout')) {
+        AdblockAlertHelper.show();
+    }
+}
+
 const MAX_RETRIES = 3;
 
-function AdBlockerFallback() {
+function AdBlockerFallback({ isNative = false }: { isNative?: boolean }) {
     const { colors, borderRadius, typography } = useTheme();
     const { t } = useTranslation();
 
     return (
-        <View style={[styles.fallback, {
-            backgroundColor: colors.card,
-            borderRadius: borderRadius.lg,
-            borderWidth: 1,
-            borderColor: colors.border,
-        }]}>
+        <View style={[
+            isNative ? styles.nativeFallback : styles.fallback,
+            {
+                backgroundColor: colors.card,
+                borderRadius: isNative ? 16 : borderRadius.lg,
+                borderWidth: 1,
+                borderColor: colors.border,
+            }
+        ]}>
             <View style={styles.fallbackContent}>
-                <MaterialIcons name="info-outline" size={20} color={colors.warning} />
+                <MaterialIcons name="info-outline" size={isNative ? 24 : 20} color={colors.warning} />
                 <View style={styles.fallbackTextContainer}>
-                    <Text style={[typography.footnote, { color: colors.text, fontWeight: '600' }]}>
+                    <Text style={[isNative ? typography.body : typography.footnote, { color: colors.text, fontWeight: '600' }]}>
                          {t('ads.blockerDetected')}
                     </Text>
-                    <Text style={[typography.caption1, { color: colors.textSecondary, marginTop: 2 }]}>
+                    <Text style={[isNative ? typography.footnote : typography.caption1, { color: colors.textSecondary, marginTop: 2 }]}>
                         {t('ads.supportDeveloper')}
                     </Text>
                 </View>
@@ -77,6 +90,7 @@ function AdBlockerFallback() {
 // 1) Standard Banner Ad Component
 export const AdBanner: React.FC = () => {
     const [isReady, setIsReady] = useState(adsInitialized);
+    const [initFailed, setInitFailed] = useState(adsInitFailed);
     const [adFailed, setAdFailed] = useState(false);
     const [retryCount, setRetryCount] = useState(0);
     const [adKey, setAdKey] = useState(0);
@@ -87,8 +101,12 @@ export const AdBanner: React.FC = () => {
     useEffect(() => {
         if (!adsInitialized && !adsInitFailed) {
             initializeAds().then(() => {
-                if (adsInitialized) setIsReady(true);
+                setIsReady(adsInitialized);
+                setInitFailed(adsInitFailed);
             });
+        } else {
+            setIsReady(adsInitialized);
+            setInitFailed(adsInitFailed);
         }
     }, []);
 
@@ -105,9 +123,7 @@ export const AdBanner: React.FC = () => {
         }
     }, [adFailed, retryCount]);
 
-    if (adsInitFailed) return null;
-
-    if (adFailed && retryCount >= MAX_RETRIES) {
+    if (adsInitFailed || initFailed || adFailed) {
         return <AdBlockerFallback />;
     }
 
@@ -124,7 +140,7 @@ export const AdBanner: React.FC = () => {
         }]}>
             {showPlaceholder && (
                 <View style={styles.placeholderContent}>
-                    <ActivityIndicator size="small" color={colors.textSecondary} style={{ opacity: 0.5 }} />
+                    <BouncingDots size="small" color={colors.textSecondary} style={{ opacity: 0.5 }} />
                 </View>
             )}
             {isReady && !adFailed && (
@@ -136,9 +152,10 @@ export const AdBanner: React.FC = () => {
                         setIsLoaded(true);
                         setRetryCount(0);
                     }}
-                    onAdFailedToLoad={() => {
+                    onAdFailedToLoad={(error) => {
                         setIsLoaded(false);
                         setAdFailed(true);
+                        triggerAdblockAlert(error);
                     }}
                 />
             )}
@@ -149,6 +166,7 @@ export const AdBanner: React.FC = () => {
 // 2) Premium Native Advanced Ad Component
 export const AdNative: React.FC = () => {
     const [isReady, setIsReady] = useState(adsInitialized);
+    const [initFailed, setInitFailed] = useState(adsInitFailed);
     const [adFailed, setAdFailed] = useState(false);
     const [retryCount, setRetryCount] = useState(0);
     const [adKey, setAdKey] = useState(0);
@@ -160,8 +178,12 @@ export const AdNative: React.FC = () => {
     useEffect(() => {
         if (!adsInitialized && !adsInitFailed) {
             initializeAds().then(() => {
-                if (adsInitialized) setIsReady(true);
+                setIsReady(adsInitialized);
+                setInitFailed(adsInitFailed);
             });
+        } else {
+            setIsReady(adsInitialized);
+            setInitFailed(adsInitFailed);
         }
     }, []);
 
@@ -173,7 +195,12 @@ export const AdNative: React.FC = () => {
             setIsLoading(true);
             setAdFailed(false);
             try {
-                const ad = await NativeAd.createForAdRequest(NATIVE_AD_UNIT_ID);
+                const adRequestPromise = NativeAd.createForAdRequest(NATIVE_AD_UNIT_ID);
+                const timeoutPromise = new Promise<never>((_, reject) =>
+                    setTimeout(() => reject(new Error('Timeout loading native ad')), 5000)
+                );
+
+                const ad = await Promise.race([adRequestPromise, timeoutPromise]);
                 if (active) {
                     adInstance = ad;
                     setNativeAd(ad);
@@ -182,10 +209,11 @@ export const AdNative: React.FC = () => {
                     ad.destroy();
                 }
             } catch (err) {
-                console.error('Failed to load native ad:', err);
+                console.warn('Failed to load native ad:', err);
                 if (active) {
                     setAdFailed(true);
                     setIsLoading(false);
+                    triggerAdblockAlert(err);
                 }
             }
         };
@@ -215,10 +243,8 @@ export const AdNative: React.FC = () => {
         }
     }, [adFailed, retryCount]);
 
-    if (adsInitFailed) return null;
-
-    if (adFailed && retryCount >= MAX_RETRIES) {
-        return <AdBlockerFallback />;
+    if (adsInitFailed || initFailed || adFailed) {
+        return <AdBlockerFallback isNative />;
     }
 
     const showPlaceholder = !isReady || adFailed || isLoading || !nativeAd;
@@ -240,7 +266,7 @@ export const AdNative: React.FC = () => {
         }]}>
             {showPlaceholder ? (
                 <View style={styles.placeholderContent}>
-                    <ActivityIndicator size="small" color={colors.textSecondary} style={{ opacity: 0.5 }} />
+                    <BouncingDots size="small" color={colors.textSecondary} style={{ opacity: 0.5 }} />
                 </View>
             ) : (
                 <NativeAdView
@@ -311,7 +337,11 @@ const styles = StyleSheet.create({
         width: '100%',
     },
     placeholderContent: {
-        height: 90,
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
         justifyContent: 'center',
         alignItems: 'center',
     },
@@ -362,6 +392,17 @@ const styles = StyleSheet.create({
     fallback: {
         padding: 12,
         marginBottom: 16,
+    },
+    nativeFallback: {
+        padding: 16,
+        marginBottom: 16,
+        minHeight: 90,
+        justifyContent: 'center',
+        shadowColor: '#000',
+        shadowOffset: { width: 0, height: 2 },
+        shadowOpacity: 0.05,
+        shadowRadius: 8,
+        elevation: 2,
     },
     fallbackContent: {
         flexDirection: 'row',

--- a/src/components/AdblockAlertModal.tsx
+++ b/src/components/AdblockAlertModal.tsx
@@ -1,0 +1,310 @@
+import React, { useState, useEffect } from 'react';
+import {
+    Modal,
+    View,
+    Text,
+    TouchableOpacity,
+    StyleSheet,
+    Dimensions,
+    Platform,
+    Animated,
+    TouchableWithoutFeedback,
+} from 'react-native';
+import { useTheme } from '@/theme';
+import { useTranslation } from '@/i18n';
+import { MaterialIcons, Ionicons } from '@expo/vector-icons';
+
+interface AdblockAlertModalProps {
+    visible?: boolean;
+    onClose?: () => void;
+}
+
+let adblockListener: ((visible: boolean) => void) | null = null;
+let hasShownAdblockAlert = false;
+
+export const setAdblockListener = (listener: (visible: boolean) => void) => {
+    adblockListener = listener;
+};
+
+export const AdblockAlertHelper = {
+    show: () => {
+        if (!hasShownAdblockAlert) {
+            hasShownAdblockAlert = true;
+            if (adblockListener) {
+                adblockListener(true);
+            }
+        }
+    },
+    hide: () => {
+        if (adblockListener) {
+            adblockListener(false);
+        }
+    },
+    reset: () => {
+        hasShownAdblockAlert = false;
+    }
+};
+
+export const AdblockAlertModal: React.FC<AdblockAlertModalProps> = () => {
+    const [visible, setVisible] = useState(false);
+    const { colors, typography, isDark, borderRadius } = useTheme();
+    const { t } = useTranslation();
+    const [slideAnim] = useState(new Animated.Value(0));
+
+    useEffect(() => {
+        setAdblockListener((vis) => {
+            if (vis) {
+                setVisible(true);
+                Animated.timing(slideAnim, {
+                    toValue: 1,
+                    duration: 300,
+                    useNativeDriver: true,
+                }).start();
+            } else {
+                Animated.timing(slideAnim, {
+                    toValue: 0,
+                    duration: 250,
+                    useNativeDriver: true,
+                }).start(() => {
+                    setVisible(false);
+                });
+            }
+        });
+        return () => {
+            setAdblockListener(() => {});
+        };
+    }, [slideAnim]);
+
+    const handleClose = () => {
+        AdblockAlertHelper.hide();
+        AdblockAlertHelper.reset();
+    };
+
+    if (!visible) return null;
+
+    const screenHeight = Dimensions.get('window').height;
+    const translateY = slideAnim.interpolate({
+        inputRange: [0, 1],
+        outputRange: [screenHeight, 0],
+    });
+
+    const backdropOpacity = slideAnim.interpolate({
+        inputRange: [0, 1],
+        outputRange: [0, 1],
+    });
+
+    return (
+        <Modal
+            visible={visible}
+            transparent
+            animationType="none"
+            onRequestClose={handleClose}
+        >
+            <View style={styles.overlay}>
+                <TouchableWithoutFeedback onPress={handleClose}>
+                    <Animated.View style={[
+                        styles.backdrop,
+                        {
+                            opacity: backdropOpacity,
+                            backgroundColor: isDark ? 'rgba(0, 0, 0, 0.75)' : 'rgba(0, 0, 0, 0.45)',
+                        }
+                    ]} />
+                </TouchableWithoutFeedback>
+
+                <Animated.View style={[
+                    styles.sheetContainer,
+                    {
+                        transform: [{ translateY }],
+                        backgroundColor: isDark ? '#1c1c1e' : '#ffffff',
+                        borderColor: isDark ? 'rgba(255, 255, 255, 0.08)' : 'rgba(0, 0, 0, 0.08)',
+                    }
+                ]}>
+                    {/* Top drag handle indicator */}
+                    <View style={[styles.dragHandle, { backgroundColor: isDark ? 'rgba(255, 255, 255, 0.15)' : 'rgba(0, 0, 0, 0.15)' }]} />
+
+                    {/* Shield Icon Container */}
+                    <View style={[
+                        styles.iconContainer,
+                        { backgroundColor: isDark ? 'rgba(239, 68, 68, 0.12)' : 'rgba(239, 68, 68, 0.08)' }
+                    ]}>
+                        <Ionicons name="shield-outline" size={32} color="#EF4444" />
+                    </View>
+
+                    {/* Title */}
+                    <Text style={[typography.headline, styles.title, { color: colors.text }]}>
+                        {t('ads.modalTitle')}
+                    </Text>
+
+                    {/* Description */}
+                    <Text style={[typography.body, styles.description, { color: colors.textSecondary }]}>
+                        {t('ads.modalDescription')}
+                    </Text>
+
+                    {/* Guide Card */}
+                    <View style={[
+                        styles.guideCard,
+                        {
+                            backgroundColor: isDark ? 'rgba(255, 255, 255, 0.03)' : 'rgba(0, 0, 0, 0.02)',
+                            borderColor: colors.border,
+                        }
+                    ]}>
+                        <View style={styles.guideHeader}>
+                            <MaterialIcons name="verified-user" size={18} color={colors.primary} />
+                            <Text style={[typography.body, styles.guideTitle, { color: colors.text }]}>
+                                {t('ads.stepsTitle')}
+                            </Text>
+                        </View>
+                        <View style={styles.stepsContainer}>
+                            <Text style={[typography.footnote, styles.stepText, { color: colors.textSecondary }]}>
+                                1. {t('ads.step1')}
+                            </Text>
+                            <Text style={[typography.footnote, styles.stepText, { color: colors.textSecondary }]}>
+                                2. {t('ads.step2')}
+                            </Text>
+                            <Text style={[typography.footnote, styles.stepText, { color: colors.textSecondary }]}>
+                                3. {t('ads.step3')}
+                            </Text>
+                        </View>
+                    </View>
+
+                    {/* Action Buttons */}
+                    <TouchableOpacity
+                        style={[styles.primaryButton, { borderRadius: borderRadius.md }]}
+                        activeOpacity={0.8}
+                        onPress={handleClose}
+                    >
+                        <Text style={styles.primaryButtonText}>
+                            {t('ads.btnIHaveDisabled')}
+                        </Text>
+                    </TouchableOpacity>
+
+                    <TouchableOpacity
+                        style={styles.secondaryButton}
+                        activeOpacity={0.7}
+                        onPress={handleClose}
+                    >
+                        <Text style={[typography.body, styles.secondaryButtonText, { color: colors.textSecondary }]}>
+                            {t('ads.btnLater')}
+                        </Text>
+                    </TouchableOpacity>
+
+                    {/* Guarantee Text Notice */}
+                    <Text style={[styles.guaranteeText, { color: colors.textSecondary }]}>
+                        {t('ads.guaranteeNotice')}
+                    </Text>
+                </Animated.View>
+            </View>
+        </Modal>
+    );
+};
+
+const { width } = Dimensions.get('window');
+
+const styles = StyleSheet.create({
+    overlay: {
+        flex: 1,
+        justifyContent: 'flex-end',
+    },
+    backdrop: {
+        ...StyleSheet.absoluteFillObject,
+    },
+    sheetContainer: {
+        width: '100%',
+        maxWidth: width > 500 ? 460 : undefined,
+        alignSelf: 'center',
+        borderTopLeftRadius: 28,
+        borderTopRightRadius: 28,
+        borderWidth: 1,
+        borderBottomWidth: 0,
+        paddingHorizontal: 24,
+        paddingTop: 8,
+        paddingBottom: Platform.OS === 'ios' ? 36 : 24,
+        shadowColor: '#000',
+        shadowOffset: { width: 0, height: -4 },
+        shadowOpacity: 0.15,
+        shadowRadius: 12,
+        elevation: 24,
+    },
+    dragHandle: {
+        width: 38,
+        height: 4,
+        borderRadius: 2,
+        alignSelf: 'center',
+        marginVertical: 12,
+    },
+    iconContainer: {
+        width: 64,
+        height: 64,
+        borderRadius: 18,
+        justifyContent: 'center',
+        alignItems: 'center',
+        alignSelf: 'center',
+        marginTop: 8,
+        marginBottom: 16,
+    },
+    title: {
+        textAlign: 'center',
+        fontWeight: 'bold',
+        marginBottom: 8,
+    },
+    description: {
+        textAlign: 'center',
+        paddingHorizontal: 12,
+        lineHeight: 20,
+        marginBottom: 20,
+    },
+    guideCard: {
+        borderRadius: 16,
+        borderWidth: 1,
+        padding: 16,
+        marginBottom: 24,
+    },
+    guideHeader: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        marginBottom: 12,
+        gap: 8,
+    },
+    guideTitle: {
+        fontWeight: '600',
+    },
+    stepsContainer: {
+        gap: 8,
+    },
+    stepText: {
+        lineHeight: 18,
+    },
+    primaryButton: {
+        backgroundColor: '#EF4444',
+        paddingVertical: 16,
+        alignItems: 'center',
+        justifyContent: 'center',
+        shadowColor: '#EF4444',
+        shadowOffset: { width: 0, height: 4 },
+        shadowOpacity: 0.2,
+        shadowRadius: 8,
+        elevation: 4,
+    },
+    primaryButtonText: {
+        color: '#ffffff',
+        fontSize: 16,
+        fontWeight: 'bold',
+    },
+    secondaryButton: {
+        paddingVertical: 14,
+        alignItems: 'center',
+        justifyContent: 'center',
+        marginTop: 4,
+        marginBottom: 12,
+    },
+    secondaryButtonText: {
+        fontWeight: '600',
+    },
+    guaranteeText: {
+        textAlign: 'center',
+        fontSize: 10,
+        lineHeight: 14,
+        paddingHorizontal: 8,
+        opacity: 0.6,
+    },
+});

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -38,3 +38,4 @@ export * from './KeyboardAnimatedView';
 export * from './CustomRefreshScrollView';
 export * from './SignalPointingModal';
 export * from './AdBanner';
+export * from './AdblockAlertModal';

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -713,7 +713,16 @@
     "adblockNoticeTitle": "AdBlock Notice",
     "adblockNoticeMessage": "Please make sure you are not using an ad blocker to enjoy all the features of this app.",
     "failedToLoad": "Failed to load advertisement. Please check your internet connection or disable your ad blocker.",
-    "adServerConnectionFailed": "Failed to connect to ad server. If you are using an ad blocker or custom DNS (like AdGuard), please disable it to load ads and support the app."
+    "adServerConnectionFailed": "Failed to connect to ad server. If you are using an ad blocker or custom DNS (like AdGuard), please disable it to load ads and support the app.",
+    "modalTitle": "Adblocker Detected! 🛑",
+    "modalDescription": "We detected an active Adblocker. Please support the developer by disabling your Adblocker.",
+    "stepsTitle": "Easy Steps to Disable:",
+    "step1": "Turn off VPN, Adblocker, or private DNS (like AdGuard) in your device settings.",
+    "step2": "Allow connections to the ad server.",
+    "step3": "Reopen the app or reload the page.",
+    "btnIHaveDisabled": "I Have Disabled Adblock",
+    "btnLater": "Later",
+    "guaranteeNotice": "We guarantee your reading comfort by limiting the number of ads displayed. Thank you for your understanding!"
   }
 }
 

--- a/src/i18n/id.json
+++ b/src/i18n/id.json
@@ -713,7 +713,16 @@
     "adblockNoticeTitle": "Pemberitahuan AdBlock",
     "adblockNoticeMessage": "Pastikan Anda tidak menggunakan adblock untuk dapat menggunakan semua fitur dalam aplikasi ini secara maksimal.",
     "failedToLoad": "Gagal memuat iklan. Silakan periksa koneksi internet Anda atau nonaktifkan pemblokir iklan.",
-    "adServerConnectionFailed": "Gagal terhubung ke server iklan. Jika Anda menggunakan pemblokir iklan (ad blocker) atau DNS kustom (seperti AdGuard), harap nonaktifkan untuk memuat iklan dan mendukung aplikasi."
+    "adServerConnectionFailed": "Gagal terhubung ke server iklan. Jika Anda menggunakan pemblokir iklan (ad blocker) atau DNS kustom (seperti AdGuard), harap nonaktifkan untuk memuat iklan dan mendukung aplikasi.",
+    "modalTitle": "Adblocker Terdeteksi! 🛑",
+    "modalDescription": "Kami mendeteksi penggunaan Adblocker aktif. Tolong dukung kelangsungan pengembang dengan menonaktifkan Adblocker Anda.",
+    "stepsTitle": "Langkah Mudah Menonaktifkan:",
+    "step1": "Matikan VPN, Adblocker, atau DNS pribadi (seperti AdGuard) di pengaturan perangkat Anda.",
+    "step2": "Izinkan koneksi ke server iklan.",
+    "step3": "Buka kembali aplikasi atau muat ulang halaman.",
+    "btnIHaveDisabled": "Saya Sudah Matikan Adblock",
+    "btnLater": "Nanti Saja",
+    "guaranteeNotice": "Kami menjamin kenyamanan Anda dengan membatasi jumlah iklan yang tayang. Terima kasih atas pengertiannya!"
   }
 }
 

--- a/src/services/ad.service.ts
+++ b/src/services/ad.service.ts
@@ -10,6 +10,7 @@ import mobileAds, {
 } from 'react-native-google-mobile-ads';
 import Constants from 'expo-constants';
 import { ThemedAlertHelper } from '@/components/ThemedAlert';
+import { AdblockAlertHelper } from '@/components/AdblockAlertModal';
 import { useThemeStore } from '@/stores/theme.store';
 import en from '@/i18n/en.json';
 import id from '@/i18n/id.json';
@@ -58,19 +59,11 @@ let isInterstitialLoading = false;
 let isRewardedLoading = false;
 let isAppOpenLoading = false;
 
-let hasShownAdblockAlert = false;
-
 function handleAdError(error: any) {
     if (!error) return;
     const errMsg = error?.message || String(error);
     if (errMsg.includes('doubleclick') || errMsg.includes('ad server') || errMsg.includes('Failed to connect')) {
-        if (!hasShownAdblockAlert) {
-            hasShownAdblockAlert = true;
-            ThemedAlertHelper.alert(
-                getTranslation('ads.blockerDetected') || 'Ad blocker detected',
-                getTranslation('ads.adServerConnectionFailed') || 'Failed to connect to ad server. If you are using an ad blocker or custom DNS (like AdGuard), please disable it to load ads and support the app.'
-            );
-        }
+        AdblockAlertHelper.show();
     }
 }
 


### PR DESCRIPTION
- Add custom AdblockAlertModal sliding bottom sheet for premium warning layout
- Integrate triggerAdblockAlert helper for immediate fallback and warning sheet display on banner/native load failures
- Implement 5-second timeout on NativeAd.createForAdRequest to prevent hanging on DNS-level ad blockers
- Fix banner ad loader vertical positioning to stay centered during loading states
- Refactor Timezone selection modal to use global glassmorphism PageSheetModal style