### PR TITLE
feat(home): redesign dashboard cards and optimize battery and ad flows

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -40,7 +40,7 @@ export default ({ config }: ConfigContext): ExpoConfig => {
         ...config,
         name: isDev ? 'HM Mobile [DEV]' : 'Huawei Manager',
         slug: 'hm-mobile',
-        version: '1.1.35',
+        version: '1.1.40',
         orientation: 'portrait',
         icon: './assets/logo.png',
         userInterfaceStyle: 'automatic',

--- a/changelog.md
+++ b/changelog.md
@@ -1,11 +1,11 @@
 # EN
 - **Bug Fixes & Maintenance** Fixes bugs in v1.1.25 reported by users, addition of ads to support app development, and general performance improvements.
 - **Multi-Modem Profile Support** Save up to 5 profiles, switch easily from settings or login, and auto-save on successful login.
-- **Aesthetic UI Enhancements** Timezone layout fixes, accent color options addition, modem connection timeout improvements, and alert on IP address change addition.
-- **Automated Logout in Background** Saves battery and prevents modem freeze by logging out when the app is minimized.
+- **Premium Dashboard Redesign** Complete visual upgrade of Connection Status, Quick Actions, and Signal Info cards with centered alignments and refined layout elements.
+- **Background Resource & Ad Optimization** Suspends background updates and widget polling to save battery when backgrounded, with capped App Open ad frequency and improved interstitial flow.
 
 # ID
 - **Perbaikan Bug & Pemeliharaan** Perbaikan bug di versi 1.1.25 yang telah dilaporkan pengguna, penambahan iklan untuk mendukung pengembangan aplikasi, serta optimalisasi performa aplikasi secara keseluruhan.
 - **Dukungan Multi-Profil Modem** Simpan hingga 5 profil, beralih dengan mudah dari pengaturan atau login, dan simpan otomatis saat berhasil login.
-- **Penyempurnaan Tampilan Premium** Perbaikan tampilan timezone, penambahan opsi warna Accent, perbaikan waktu tunggu terhubung dengan modem, dan penambahan alert ketika IP berubah.
-- **Logout Otomatis di Latar Belakang** Menghemat baterai dan mencegah modem macet dengan melakukan logout otomatis saat aplikasi diminimalkan.
+- **Desain Ulang Tampilan Premium** Pembaruan visual total untuk kartu Status Koneksi, Aksi Cepat, dan Informasi Sinyal dengan penataan teks di tengah dan perbaikan tata letak.
+- **Optimalisasi Baterai & Frekuensi Iklan** Penghentian otomatis polling latar belakang dan pembaruan widget untuk menghemat baterai, serta penataan jeda iklan agar tidak mengganggu navigasi.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hm-mobile",
-  "version": "1.1.35",
+  "version": "1.1.40",
   "main": "index.js",
   "scripts": {
     "start": "expo start",

--- a/src/app/(tabs)/home.tsx
+++ b/src/app/(tabs)/home.tsx
@@ -7,6 +7,7 @@ import {
   TouchableOpacity,
   Platform,
   StatusBar,
+  AppState,
 } from 'react-native';
 import { useRouter } from 'expo-router';
 import AsyncStorage from '@react-native-async-storage/async-storage';
@@ -159,11 +160,15 @@ export default function HomeScreen() {
       checkDebugReminder();
 
       const fastIntervalId = setInterval(() => {
-        loadTrafficOnly(service);
+        if (AppState.currentState === 'active') {
+          loadTrafficOnly(service);
+        }
       }, 1000);
 
       const slowIntervalId = setInterval(() => {
-        loadDataSilent(service);
+        if (AppState.currentState === 'active') {
+          loadDataSilent(service);
+        }
       }, 5000);
 
       return () => {
@@ -575,7 +580,6 @@ export default function HomeScreen() {
       ]);
       setDiagnosisSummary(t(`home.${result.summaryKey}`));
       setShowDiagnosisModal(true);
-      showInterstitial(() => { });
     } catch (error: any) {
       console.error('Error running one click check:', error);
       if (error?.message?.includes('Network Error') || error?.code === 'ERR_NETWORK') {
@@ -868,7 +872,12 @@ export default function HomeScreen() {
           {/* Diagnosis Result Modal */}
           <DiagnosisResultModal
             visible={showDiagnosisModal}
-            onClose={() => setShowDiagnosisModal(false)}
+            onClose={() => {
+              setShowDiagnosisModal(false);
+              if (diagnosisTitle === t('home.oneClickCheckResult')) {
+                showInterstitial(() => { });
+              }
+            }}
             title={diagnosisTitle}
             results={diagnosisResults}
             summary={diagnosisSummary}

--- a/src/app/(tabs)/sms.tsx
+++ b/src/app/(tabs)/sms.tsx
@@ -10,6 +10,7 @@ import {
   Platform,
   TextInput,
   Linking,
+  AppState,
 } from 'react-native';
 import { MaterialIcons } from '@expo/vector-icons';
 import dayjs from 'dayjs';
@@ -67,7 +68,9 @@ export default function SMSScreen() {
       loadData(service);
 
       const intervalId = setInterval(() => {
-        loadDataSilent(service);
+        if (AppState.currentState === 'active') {
+          loadDataSilent(service);
+        }
       }, 10000);
 
       return () => clearInterval(intervalId);

--- a/src/app/(tabs)/wifi.tsx
+++ b/src/app/(tabs)/wifi.tsx
@@ -12,6 +12,7 @@ import {
   KeyboardAvoidingView,
   Keyboard,
   Pressable,
+  AppState,
 } from 'react-native';
 import { MaterialIcons } from '@expo/vector-icons';
 import { useTheme } from '@/theme';
@@ -145,7 +146,9 @@ export default function WiFiScreen() {
       loadData(service);
 
       const intervalId = setInterval(() => {
-        loadDataSilent(service);
+        if (AppState.currentState === 'active') {
+          loadDataSilent(service);
+        }
       }, 5000);
 
       return () => clearInterval(intervalId);

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -22,6 +22,17 @@ import { KeyboardProvider } from 'react-native-keyboard-controller';
 import { initAdMob, showAppOpenAd } from '@/services/ad.service';
 
 
+// const getFcmToken = async () => {
+//   try {
+//     const deviceToken = await Notifications.getDevicePushTokenAsync();
+//     console.log("🔥 FCM REGISTRATION TOKEN ANDROID:");
+//     console.log(deviceToken.data);
+//   } catch (error) {
+//     console.error("Gagal mengambil token:", error);
+//   }
+// };
+// getFcmToken();
+
 SplashScreen.preventAutoHideAsync();
 
 interface AlertButton {

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -71,6 +71,8 @@ export default function RootLayout() {
     const router = useRouter();
 
     const appStateRef = useRef<AppStateStatus>(AppState.currentState);
+    const backgroundTimeRef = useRef<number>(0);
+    const lastAppOpenShowTimeRef = useRef<number>(0);
     const [isRestoringSession, setIsRestoringSession] = useState(false);
     const [authReady, setAuthReady] = useState(false);
 
@@ -262,7 +264,15 @@ export default function RootLayout() {
             appStateRef.current = nextAppState;
 
             if (previousState.match(/inactive|background/) && nextAppState === 'active') {
-                showAppOpenAd();
+                const now = Date.now();
+                const timeInBackground = now - backgroundTimeRef.current;
+                const timeSinceLastAd = now - lastAppOpenShowTimeRef.current;
+
+                if (backgroundTimeRef.current > 0 && timeInBackground > 15000 && timeSinceLastAd > 60000) {
+                    lastAppOpenShowTimeRef.current = now;
+                    showAppOpenAd();
+                }
+
                 const { credentials, isAuthenticated } = useAuthStore.getState();
 
                 if (credentials && isAuthenticated) {
@@ -282,6 +292,7 @@ export default function RootLayout() {
             }
 
             if (nextAppState.match(/inactive|background/)) {
+                backgroundTimeRef.current = Date.now();
                 stopSessionKeepAlive();
             }
         };

--- a/src/components/AdBanner.tsx
+++ b/src/components/AdBanner.tsx
@@ -73,10 +73,10 @@ function AdBlockerFallback({ isNative = false }: { isNative?: boolean }) {
             }
         ]}>
             <View style={styles.fallbackContent}>
-                <MaterialIcons name="info-outline" size={isNative ? 24 : 20} color={colors.warning} />
+                <MaterialIcons name="info-outline" size={isNative ? 20 : 18} color={colors.warning} />
                 <View style={styles.fallbackTextContainer}>
                     <Text style={[isNative ? typography.body : typography.footnote, { color: colors.text, fontWeight: '600' }]}>
-                         {t('ads.blockerDetected')}
+                        {t('ads.blockerDetected')}
                     </Text>
                     <Text style={[isNative ? typography.footnote : typography.caption1, { color: colors.textSecondary, marginTop: 2 }]}>
                         {t('ads.supportDeveloper')}
@@ -394,19 +394,20 @@ const styles = StyleSheet.create({
         marginBottom: 16,
     },
     nativeFallback: {
-        padding: 16,
+        padding: 18,
         marginBottom: 16,
         minHeight: 90,
         justifyContent: 'center',
         shadowColor: '#000',
         shadowOffset: { width: 0, height: 2 },
         shadowOpacity: 0.05,
-        shadowRadius: 8,
+        shadowRadius: 4,
         elevation: 2,
     },
     fallbackContent: {
         flexDirection: 'row',
         alignItems: 'center',
+        padding: 6,
     },
     fallbackTextContainer: {
         flex: 1,

--- a/src/components/CollapsibleCard.tsx
+++ b/src/components/CollapsibleCard.tsx
@@ -5,6 +5,8 @@ import {
     StyleSheet,
     TouchableOpacity,
     LayoutAnimation,
+    StyleProp,
+    TextStyle,
 } from 'react-native';
 import { MaterialIcons } from '@expo/vector-icons';
 import { useTheme } from '@/theme';
@@ -16,6 +18,8 @@ interface CollapsibleCardProps {
     children: React.ReactNode;
     defaultExpanded?: boolean;
     onToggle?: (expanded: boolean) => void;
+    headerRight?: React.ReactNode;
+    titleStyle?: StyleProp<TextStyle>;
 }
 
 /**
@@ -27,6 +31,8 @@ export function CollapsibleCard({
     children,
     defaultExpanded = true,
     onToggle,
+    headerRight,
+    titleStyle,
 }: CollapsibleCardProps) {
     const { colors, typography, spacing } = useTheme();
     const [isExpanded, setIsExpanded] = useState(defaultExpanded);
@@ -50,10 +56,19 @@ export function CollapsibleCard({
                     size={24}
                     color={colors.textSecondary}
                 />
-                <Text style={[typography.headline, { color: colors.text, flex: 1, textAlign: 'center' }]}>
+                <Text style={[
+                    typography.headline,
+                    {
+                        color: colors.text,
+                        flex: 1,
+                        textAlign: headerRight ? 'left' : 'center',
+                        marginLeft: headerRight ? 8 : 0,
+                    },
+                    titleStyle
+                ]}>
                     {title}
                 </Text>
-                <View style={{ width: 24 }} />
+                {headerRight ? headerRight : <View style={{ width: 24 }} />}
             </TouchableOpacity>
 
             {isExpanded && (

--- a/src/components/home/ConnectionStatusCard.tsx
+++ b/src/components/home/ConnectionStatusCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
 import { MaterialIcons } from '@expo/vector-icons';
 import TextTicker from 'react-native-text-ticker';
 import { useTheme } from '@/theme';
@@ -59,7 +59,7 @@ export function ConnectionStatusCard({
     wanInfo,
     trafficStats,
 }: ConnectionStatusCardProps) {
-    const { colors, typography } = useTheme();
+    const { colors, typography, isDark } = useTheme();
 
     const getStrengthLabel = () => {
         const strength = getSignalStrength(signalInfo?.rssi, signalInfo?.rsrp);
@@ -96,186 +96,192 @@ export function ConnectionStatusCard({
         return `${value} ${sizes[i]}`;
     };
 
+    const getPowerSourceInfo = () => {
+        const isCharging = modemStatus?.batteryStatus === '1';
+        const hasBattery = modemStatus?.batteryPercent !== undefined && modemStatus?.batteryPercent !== '' && modemStatus?.batteryPercent !== null;
+        const percent = parseInt(modemStatus?.batteryPercent || '0', 10);
+
+        if (!hasBattery || isCharging) {
+            return {
+                icon: 'power' as const,
+                iconColor: colors.success,
+                text: t('home.acPower'),
+            };
+        }
+        
+        return {
+            icon: 'battery-std' as const,
+            iconColor: percent <= 20 ? colors.error : percent <= 50 ? colors.warning : colors.success,
+            text: `${t('home.battery')} (${percent}%)`,
+        };
+    };
+
+    const statusText = getStatusText();
+    const isStatusConnected = isConnected;
+
+    const headerRightBadge = (
+        <View style={[
+            styles.headerStatusBadge,
+            {
+                borderColor: isStatusConnected ? colors.success : colors.error,
+                backgroundColor: isStatusConnected ? 'rgba(34, 197, 94, 0.1)' : 'rgba(239, 68, 68, 0.1)',
+            }
+        ]}>
+            <Text style={[
+                typography.caption1,
+                {
+                    color: isStatusConnected ? colors.success : colors.error,
+                    fontWeight: '700',
+                }
+            ]}>
+                {statusText}
+            </Text>
+        </View>
+    );
+
+    const gridItemBg = isDark ? 'rgba(255, 255, 255, 0.03)' : 'rgba(0, 0, 0, 0.02)';
+    const gridItemBorder = isDark ? 'rgba(255, 255, 255, 0.06)' : 'rgba(0, 0, 0, 0.05)';
+    const powerInfo = getPowerSourceInfo();
+
     return (
-        <CollapsibleCard title={t('home.connectionStatus')}>
-            <View style={styles.connectionMainRow}>
-                <View style={styles.connectionLeftSection}>
+        <CollapsibleCard 
+            title={t('home.connectionStatus').toUpperCase()}
+            headerRight={headerRightBadge}
+            titleStyle={styles.cardTitle}
+        >
+            <View style={styles.topRow}>
+                <View style={styles.providerSection}>
                     <SignalBar strength={getSignalBars()} label="" />
-                    <View style={styles.connectionSignalLabels}>
-                        <View style={{ flex: 1, overflow: 'hidden', justifyContent: 'center', width: '100%' }}>
-                            <TextTicker
-                                style={StyleSheet.flatten([typography.subheadline, { color: colors.primary, fontWeight: '600' }])}
-                                duration={4000}
-                                loop
-                                bounce
-                                repeatSpacer={50}
-                                marqueeDelay={1000}
-                            >
-                                {getStrengthLabel()}
-                            </TextTicker>
-                        </View>
-                        <View style={{ flex: 1, overflow: 'hidden', justifyContent: 'center', width: '100%', marginTop: 2 }}>
-                            <TextTicker
-                                style={StyleSheet.flatten([typography.headline, { color: colors.text, fontWeight: '600' }])}
-                                duration={4000}
-                                loop
-                                bounce
-                                repeatSpacer={50}
-                                marqueeDelay={1000}
-                            >
-                                {networkInfo?.shortName || networkInfo?.fullName || networkInfo?.networkName || networkInfo?.spnName || t('common.unknown')}
-                            </TextTicker>
+                    <View style={styles.providerInfoColumn}>
+                        <Text style={styles.sectionLabel}>{t('home.provider').toUpperCase()}</Text>
+                        <View style={styles.providerNameRow}>
+                            <View style={{ overflow: 'hidden', flexShrink: 1, marginRight: 8 }}>
+                                <TextTicker
+                                    style={StyleSheet.flatten([typography.title3, { color: colors.text, fontWeight: '700' }])}
+                                    duration={4000}
+                                    loop
+                                    bounce
+                                    repeatSpacer={50}
+                                    marqueeDelay={1000}
+                                >
+                                    {networkInfo?.shortName || networkInfo?.fullName || networkInfo?.networkName || networkInfo?.spnName || t('common.unknown')}
+                                </TextTicker>
+                            </View>
+                            <View style={[
+                                styles.networkBadge,
+                                {
+                                    borderColor: colors.primary,
+                                    backgroundColor: isDark ? 'rgba(129, 140, 248, 0.15)' : 'rgba(79, 70, 229, 0.1)',
+                                }
+                            ]}>
+                                <Text
+                                    style={[typography.caption2, { color: colors.primary, fontWeight: '700' }]}
+                                    adjustsFontSizeToFit
+                                    numberOfLines={1}
+                                >
+                                    {networkType}
+                                </Text>
+                            </View>
                         </View>
                     </View>
                 </View>
 
-                <View style={styles.connectionCenterSection}>
-                    <View style={styles.speedRow}>
-                        <MaterialIcons name="arrow-downward" size={14} color="#22d3ee" />
-                        <Text style={[typography.caption1, { color: colors.text, fontWeight: '600', marginLeft: 2 }]} numberOfLines={1}>
+                <View style={styles.speedSection}>
+                    <Text style={[styles.sectionLabel, { textAlign: 'right' }]}>{t('home.networkSpeed').toUpperCase()}</Text>
+                    <View style={[styles.speedSubRow, { marginTop: 4 }]}>
+                        <MaterialIcons name="arrow-downward" size={16} color="#22c55e" />
+                        <Text style={[typography.body, { color: '#22c55e', fontWeight: '700', marginLeft: 4 }]}>
                             {formatSpeed((trafficStats?.currentDownloadRate || 0) * 8)}
                         </Text>
                     </View>
-                    <View style={[styles.speedRow, { marginTop: 4 }]}>
-                        <MaterialIcons name="arrow-upward" size={14} color="#e879f9" />
-                        <Text style={[typography.caption1, { color: colors.text, fontWeight: '600', marginLeft: 2 }]} numberOfLines={1}>
+                    <View style={[styles.speedSubRow, { marginTop: 2 }]}>
+                        <MaterialIcons name="arrow-upward" size={16} color="#e879f9" />
+                        <Text style={[typography.body, { color: '#e879f9', fontWeight: '700', marginLeft: 4 }]}>
                             {formatSpeed((trafficStats?.currentUploadRate || 0) * 8)}
-                        </Text>
-                    </View>
-                </View>
-
-                <View style={styles.connectionRightSection}>
-                    <TextTicker
-                        style={StyleSheet.flatten([
-                            typography.subheadline,
-                            {
-                                color: isConnected ? colors.primary : colors.error,
-                                fontWeight: '600',
-                                marginBottom: 4,
-                            }
-                        ])}
-                        duration={4000}
-                        loop
-                        bounce
-                        repeatSpacer={50}
-                        marqueeDelay={1000}
-                    >
-                        {getStatusText()}
-                    </TextTicker>
-                    <View style={[styles.networkTypeBadge, { borderColor: colors.primary, borderWidth: 1 }]}>
-                        <Text
-                            style={[typography.caption1, { color: colors.primary, fontWeight: '700' }]}
-                            adjustsFontSizeToFit
-                            numberOfLines={1}
-                        >
-                            {networkType}
                         </Text>
                     </View>
                 </View>
             </View>
 
-            <View style={{ height: 1, backgroundColor: colors.border, marginVertical: 12 }} />
+            <View style={[styles.divider, { backgroundColor: colors.border }]} />
 
-            <View style={styles.connectionInfoGrid}>
-                <View style={styles.connectionInfoGridItem}>
-                    <TextTicker
-                        style={StyleSheet.flatten([typography.caption1, { color: colors.textSecondary, marginBottom: 2 }])}
-                        duration={4000}
-                        loop
-                        bounce
-                        repeatSpacer={50}
-                        marqueeDelay={1000}
-                    >
-                        {t('home.power')}
-                    </TextTicker>
-                    <BatteryIndicator
-                        batteryStatus={modemStatus?.batteryStatus}
-                        batteryLevel={modemStatus?.batteryLevel}
-                        batteryPercent={modemStatus?.batteryPercent}
-                        size="medium"
-                    />
+            <View style={styles.gridContainer}>
+                {/* Aliran Daya */}
+                <View style={[styles.gridItem, { backgroundColor: gridItemBg, borderColor: gridItemBorder, width: '48.5%', marginBottom: 12 }]}>
+                    <Text style={styles.gridItemLabel}>{t('home.powerSource').toUpperCase()}</Text>
+                    <View style={styles.gridItemContent}>
+                        <MaterialIcons name={powerInfo.icon} size={18} color={powerInfo.iconColor} />
+                        <Text style={[typography.subheadline, { color: colors.text, fontWeight: '700', marginLeft: 8 }]}>
+                            {powerInfo.text}
+                        </Text>
+                    </View>
                 </View>
 
-                <View style={styles.connectionInfoGridItem}>
-                    <TextTicker
-                        style={StyleSheet.flatten([typography.caption1, { color: colors.textSecondary, marginBottom: 2 }])}
-                        duration={4000}
-                        loop
-                        bounce
-                        repeatSpacer={50}
-                        marqueeDelay={1000}
-                    >
-                        {t('home.ipAddress')}
-                    </TextTicker>
-                    <TextTicker
-                        style={StyleSheet.flatten([typography.subheadline, { color: colors.text, fontWeight: '600' }])}
-                        duration={4000}
-                        loop
-                        bounce
-                        repeatSpacer={50}
-                        marqueeDelay={1000}
-                    >
-                        {wanInfo?.wanIPAddress || '...'}
-                    </TextTicker>
+                {/* Alamat IP */}
+                <View style={[styles.gridItem, { backgroundColor: gridItemBg, borderColor: gridItemBorder, width: '48.5%', marginBottom: 12 }]}>
+                    <Text style={styles.gridItemLabel}>{t('home.ipAddress').toUpperCase()}</Text>
+                    <View style={styles.gridItemContent}>
+                        <MaterialIcons name="public" size={18} color="#c084fc" />
+                        <View style={{ flex: 1, marginLeft: 8, overflow: 'hidden' }}>
+                            <TextTicker
+                                style={StyleSheet.flatten([typography.subheadline, { color: colors.text, fontWeight: '700' }])}
+                                duration={4000}
+                                loop
+                                bounce
+                                repeatSpacer={50}
+                                marqueeDelay={1000}
+                            >
+                                {wanInfo?.wanIPAddress || '...'}
+                            </TextTicker>
+                        </View>
+                    </View>
                 </View>
 
-                <View style={styles.connectionInfoGridItem}>
-                    <TextTicker
-                        style={StyleSheet.flatten([typography.caption1, { color: colors.textSecondary, marginBottom: 2 }])}
-                        duration={4000}
-                        loop
-                        bounce
-                        repeatSpacer={50}
-                        marqueeDelay={1000}
-                    >
-                        {t('home.band')}
-                    </TextTicker>
-                    <TextTicker
-                        style={StyleSheet.flatten([typography.subheadline, { color: colors.text, fontWeight: '600' }])}
-                        duration={4000}
-                        loop
-                        bounce
-                        repeatSpacer={50}
-                        marqueeDelay={1000}
-                    >
-                        {getLteBandInfo(signalInfo?.band)}
-                    </TextTicker>
+                {/* Frekuensi / Band */}
+                <View style={[styles.gridItem, { backgroundColor: gridItemBg, borderColor: gridItemBorder, width: '48.5%', marginBottom: 12 }]}>
+                    <Text style={styles.gridItemLabel}>{t('home.frequencyBand').toUpperCase()}</Text>
+                    <View style={styles.gridItemContent}>
+                        <MaterialIcons name="rss-feed" size={18} color="#a78bfa" />
+                        <View style={{ flex: 1, marginLeft: 8, overflow: 'hidden' }}>
+                            <TextTicker
+                                style={StyleSheet.flatten([typography.subheadline, { color: colors.text, fontWeight: '700' }])}
+                                duration={4000}
+                                loop
+                                bounce
+                                repeatSpacer={50}
+                                marqueeDelay={1000}
+                            >
+                                {getLteBandInfo(signalInfo?.band) || '-'}
+                            </TextTicker>
+                        </View>
+                    </View>
                 </View>
 
-                <View style={styles.connectionInfoGridItem}>
-                    <TextTicker
-                        style={StyleSheet.flatten([typography.caption1, { color: colors.textSecondary, marginBottom: 2 }])}
-                        duration={4000}
-                        loop
-                        bounce
-                        repeatSpacer={50}
-                        marqueeDelay={1000}
-                    >
-                        {t('home.width')}
-                    </TextTicker>
-                    <View style={{ flexDirection: 'row', alignItems: 'center' }}>
-                        {signalInfo?.dlbandwidth || signalInfo?.ulbandwidth ? (
-                            <>
-                                <MaterialIcons name="arrow-upward" size={14} color={colors.primary} />
-                                <Text
-                                    style={[typography.subheadline, { color: colors.text, fontWeight: '600', marginRight: 4 }]}
-                                    adjustsFontSizeToFit
-                                    numberOfLines={1}
-                                >
-                                    {signalInfo.ulbandwidth || '-'}
-                                </Text>
-                                <MaterialIcons name="arrow-downward" size={14} color={colors.success} />
-                                <Text
-                                    style={[typography.subheadline, { color: colors.text, fontWeight: '600' }]}
-                                    adjustsFontSizeToFit
-                                    numberOfLines={1}
-                                >
-                                    {signalInfo.dlbandwidth || '-'}
-                                </Text>
-                            </>
-                        ) : (
-                            <Text style={[typography.subheadline, { color: colors.text, fontWeight: '600' }]}>-</Text>
-                        )}
+                {/* Bandwidth */}
+                <View style={[styles.gridItem, { backgroundColor: gridItemBg, borderColor: gridItemBorder, width: '48.5%', marginBottom: 12 }]}>
+                    <Text style={styles.gridItemLabel}>{t('home.bandwidth').toUpperCase()}</Text>
+                    <View style={styles.gridItemContent}>
+                        <MaterialIcons name="show-chart" size={18} color="#22d3ee" />
+                        <View style={{ flexDirection: 'row', alignItems: 'center', marginLeft: 8, flexWrap: 'wrap', flex: 1 }}>
+                            {signalInfo?.dlbandwidth || signalInfo?.ulbandwidth ? (
+                                <>
+                                    <View style={{ flexDirection: 'row', alignItems: 'center', marginRight: 8 }}>
+                                        <MaterialIcons name="arrow-upward" size={12} color="#e879f9" />
+                                        <Text style={[typography.caption1, { color: '#e879f9', fontWeight: '700' }]}>
+                                            {signalInfo.ulbandwidth || '-'}
+                                        </Text>
+                                    </View>
+                                    <View style={{ flexDirection: 'row', alignItems: 'center' }}>
+                                        <MaterialIcons name="arrow-downward" size={12} color="#22d3ee" />
+                                        <Text style={[typography.caption1, { color: '#22d3ee', fontWeight: '700' }]}>
+                                            {signalInfo.dlbandwidth || '-'}
+                                        </Text>
+                                    </View>
+                                </>
+                            ) : (
+                                <Text style={[typography.subheadline, { color: colors.text, fontWeight: '700' }]}>-</Text>
+                            )}
+                        </View>
                     </View>
                 </View>
             </View>
@@ -284,50 +290,86 @@ export function ConnectionStatusCard({
 }
 
 const styles = StyleSheet.create({
-    connectionMainRow: {
-        flexDirection: 'row',
-        alignItems: 'center',
-        justifyContent: 'space-between',
+    cardTitle: {
+        fontSize: 12,
+        fontWeight: '600',
+        letterSpacing: 0.5,
+        color: '#8e8e93',
     },
-    connectionLeftSection: {
-        flexDirection: 'row',
-        alignItems: 'center',
-        flex: 1.4,
-        flexShrink: 1,
-        overflow: 'hidden',
-    },
-    connectionSignalLabels: {
-        marginLeft: 12,
-        flex: 1,
-        flexShrink: 1,
-        overflow: 'hidden',
-    },
-    connectionCenterSection: {
+    headerStatusBadge: {
+        borderWidth: 1,
+        borderRadius: 20,
+        paddingHorizontal: 12,
+        paddingVertical: 4,
         alignItems: 'center',
         justifyContent: 'center',
-        paddingHorizontal: 4,
-        flex: 0.8,
     },
-    connectionRightSection: {
+    topRow: {
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        paddingVertical: 4,
+    },
+    providerSection: {
+        flex: 1.4,
+        flexDirection: 'row',
+        alignItems: 'center',
+        marginRight: 8,
+    },
+    providerInfoColumn: {
+        marginLeft: 12,
+        flex: 1,
+        justifyContent: 'center',
+    },
+    providerNameRow: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        marginTop: 2,
+    },
+    sectionLabel: {
+        fontSize: 10,
+        fontWeight: '600',
+        color: '#8e8e93',
+        letterSpacing: 0.5,
+    },
+    speedSection: {
+        flex: 1,
         alignItems: 'flex-end',
-        flex: 0.8,
     },
-    speedRow: {
+    speedSubRow: {
         flexDirection: 'row',
         alignItems: 'center',
     },
-    networkTypeBadge: {
-        paddingHorizontal: 8,
-        paddingVertical: 2,
+    networkBadge: {
+        borderWidth: 1,
         borderRadius: 4,
+        paddingHorizontal: 6,
+        paddingVertical: 2,
     },
-    connectionInfoGrid: {
+    divider: {
+        height: 1,
+        marginVertical: 16,
+    },
+    gridContainer: {
         flexDirection: 'row',
         flexWrap: 'wrap',
+        justifyContent: 'space-between',
     },
-    connectionInfoGridItem: {
-        width: '50%',
-        marginBottom: 12,
+    gridItem: {
+        borderRadius: 12,
+        padding: 12,
+        borderWidth: 1,
+    },
+    gridItemLabel: {
+        fontSize: 9,
+        fontWeight: '600',
+        color: '#8e8e93',
+        letterSpacing: 0.5,
+        marginBottom: 6,
+    },
+    gridItemContent: {
+        flexDirection: 'row',
+        alignItems: 'center',
     },
 });
 

--- a/src/components/home/QuickActionsCard.tsx
+++ b/src/components/home/QuickActionsCard.tsx
@@ -42,19 +42,28 @@ export function QuickActionsCard({
 }: QuickActionsCardProps) {
     const { colors, typography, isDark } = useTheme();
 
+    const itemBg = isDark ? 'rgba(255, 255, 255, 0.03)' : 'rgba(0, 0, 0, 0.02)';
+    const itemBorder = isDark ? 'rgba(255, 255, 255, 0.06)' : 'rgba(0, 0, 0, 0.05)';
+
     return (
-        <CollapsibleCard title={t('home.actions')}>
-            <View style={styles.quickActionsRow}>
+        <CollapsibleCard 
+            title={t('home.actions').toUpperCase()}
+            titleStyle={styles.cardTitle}
+        >
+            {/* Top row - Large actions */}
+            <View style={styles.topRow}>
+                {/* Pilih Band */}
                 <TouchableOpacity
-                    style={[styles.quickActionLarge, { backgroundColor: colors.card, borderColor: colors.border, borderWidth: 1 }]}
+                    style={[styles.largeAction, { backgroundColor: itemBg, borderColor: itemBorder }]}
                     onPress={onOpenBandModal}
+                    activeOpacity={0.7}
                 >
-                    <View style={[styles.quickActionIcon, { backgroundColor: isDark ? 'rgba(255,255,255,0.1)' : colors.background }]}>
-                        <MaterialIcons name="settings-input-antenna" size={20} color={colors.primary} />
+                    <View style={[styles.largeIconContainer, { backgroundColor: 'rgba(167, 139, 250, 0.15)' }]}>
+                        <MaterialIcons name="tune" size={20} color="#a78bfa" />
                     </View>
-                    <View style={styles.quickActionLargeContent}>
+                    <View style={styles.largeActionContent}>
                         <TextTicker
-                            style={StyleSheet.flatten([typography.subheadline, { color: colors.text, fontWeight: '600' }])}
+                            style={StyleSheet.flatten([typography.subheadline, { color: colors.text, fontWeight: '700' }])}
                             duration={4000}
                             loop
                             bounce
@@ -64,7 +73,7 @@ export function QuickActionsCard({
                             {t('home.setBand')}
                         </TextTicker>
                         <TextTicker
-                            style={StyleSheet.flatten([typography.caption2, { color: colors.textSecondary }])}
+                            style={StyleSheet.flatten([typography.caption2, { color: colors.textSecondary, marginTop: 2 }])}
                             duration={6000}
                             loop
                             bounce
@@ -74,25 +83,27 @@ export function QuickActionsCard({
                             {selectedBands.length > 0 ? selectedBands.join(', ') : t('common.loading')}
                         </TextTicker>
                     </View>
-                    <MaterialIcons name="chevron-right" size={24} color={colors.textSecondary} />
+                    <MaterialIcons name="chevron-right" size={20} color={colors.textSecondary} />
                 </TouchableOpacity>
 
+                {/* Ganti IP */}
                 <TouchableOpacity
-                    style={[styles.quickActionLarge, { backgroundColor: colors.card, borderColor: colors.border, borderWidth: 1 }]}
+                    style={[styles.largeAction, { backgroundColor: itemBg, borderColor: itemBorder }]}
                     onPress={onChangeIp}
                     disabled={isChangingIp}
+                    activeOpacity={0.7}
                 >
-                    <View style={[styles.quickActionIcon, { backgroundColor: isDark ? 'rgba(255,255,255,0.1)' : colors.background }]}>
+                    <View style={[styles.largeIconContainer, { backgroundColor: 'rgba(34, 211, 238, 0.15)' }]}>
                         {isChangingIp ? (
-                            <BouncingDots size="small" color={colors.primary} />
+                            <BouncingDots size="small" color="#22d3ee" />
                         ) : (
-                            <MaterialIcons name="sync" size={20} color={colors.primary} />
+                            <MaterialIcons name="sync" size={20} color="#22d3ee" />
                         )}
                     </View>
-                    <View style={styles.quickActionLargeContent}>
+                    <View style={styles.largeActionContent}>
                         <TextTicker
-                            style={StyleSheet.flatten([typography.subheadline, { color: colors.text, fontWeight: '600' }])}
-                            duration={6000}
+                            style={StyleSheet.flatten([typography.subheadline, { color: colors.text, fontWeight: '700' }])}
+                            duration={4000}
                             loop
                             bounce
                             repeatSpacer={50}
@@ -101,7 +112,7 @@ export function QuickActionsCard({
                             {t('home.changeIp')}
                         </TextTicker>
                         <TextTicker
-                            style={StyleSheet.flatten([typography.caption2, { color: colors.textSecondary }])}
+                            style={StyleSheet.flatten([typography.caption2, { color: colors.textSecondary, marginTop: 2 }])}
                             duration={6000}
                             loop
                             bounce
@@ -111,109 +122,138 @@ export function QuickActionsCard({
                             {wanIpAddress || '...'}
                         </TextTicker>
                     </View>
+                    <MaterialIcons name="chevron-right" size={20} color={colors.textSecondary} />
                 </TouchableOpacity>
             </View>
 
-            <View style={styles.quickActionsRow}>
+            {/* Bottom row - Small actions */}
+            <View style={styles.bottomRow}>
+                {/* Data Seluler */}
                 <TouchableOpacity
                     style={[
-                        styles.quickActionSmall,
+                        styles.smallAction,
                         {
-                            backgroundColor: mobileDataEnabled ? colors.primary : colors.card,
-                            borderColor: colors.border,
+                            backgroundColor: mobileDataEnabled ? colors.primary : itemBg,
+                            borderColor: mobileDataEnabled ? colors.primary : itemBorder,
                             borderWidth: 1,
                         }
                     ]}
                     onPress={onToggleMobileData}
                     disabled={isTogglingData}
+                    activeOpacity={0.7}
                 >
                     {isTogglingData ? (
                         <BouncingDots size="small" color={mobileDataEnabled ? '#FFFFFF' : colors.primary} />
                     ) : (
                         <>
-                            <MaterialIcons
-                                name="swap-vert"
-                                size={22}
-                                color={mobileDataEnabled ? '#FFFFFF' : colors.primary}
-                            />
-                            <TextTicker
-                                style={StyleSheet.flatten([
-                                    typography.caption2,
-                                    {
-                                        color: mobileDataEnabled ? '#FFFFFF' : colors.text,
-                                        fontWeight: '500',
-                                        marginTop: 4,
-                                        textAlign: 'center',
-                                    }
-                                ])}
-                                duration={6000}
-                                loop
-                                bounce
-                                repeatSpacer={50}
-                                marqueeDelay={1000}
-                            >
-                                {t('home.mobileData')}
-                            </TextTicker>
+                            <View style={[
+                                styles.smallIconCircle, 
+                                { backgroundColor: mobileDataEnabled ? 'rgba(255, 255, 255, 0.2)' : 'rgba(236, 72, 153, 0.15)' }
+                            ]}>
+                                <MaterialIcons 
+                                    name="swap-vert" 
+                                    size={20} 
+                                    color={mobileDataEnabled ? '#FFFFFF' : '#ec4899'} 
+                                />
+                            </View>
+                            <View style={{ width: '100%', overflow: 'hidden', marginTop: 8, alignItems: 'center', justifyContent: 'center' }}>
+                                <TextTicker
+                                    style={StyleSheet.flatten([
+                                        typography.caption2, 
+                                        { 
+                                            color: mobileDataEnabled ? '#FFFFFF' : colors.text, 
+                                            fontWeight: '600', 
+                                            textAlign: 'center',
+                                            alignSelf: 'center'
+                                        }
+                                    ])}
+                                    duration={4000}
+                                    loop
+                                    bounce
+                                    repeatSpacer={50}
+                                    marqueeDelay={1000}
+                                >
+                                    {t('home.mobileData')}
+                                </TextTicker>
+                            </View>
                         </>
                     )}
                 </TouchableOpacity>
 
+                {/* Cari Sinyal */}
                 <TouchableOpacity
-                    style={[styles.quickActionSmall, { backgroundColor: colors.card, borderColor: colors.border, borderWidth: 1 }]}
+                    style={[styles.smallAction, { backgroundColor: itemBg, borderColor: itemBorder }]}
                     onPress={onSignalPointing}
+                    activeOpacity={0.7}
                 >
-                    <MaterialIcons name="gps-fixed" size={22} color={colors.primary} />
-                    <TextTicker
-                        style={StyleSheet.flatten([typography.caption2, { color: colors.text, fontWeight: '500', marginTop: 4, textAlign: 'center' }])}
-                        duration={6000}
-                        loop
-                        bounce
-                        repeatSpacer={50}
-                        marqueeDelay={1000}
-                    >
-                        {t('home.signalPointing')}
-                    </TextTicker>
+                    <View style={[styles.smallIconCircle, { backgroundColor: 'rgba(99, 102, 241, 0.15)' }]}>
+                        <MaterialIcons name="location-on" size={20} color="#6366f1" />
+                    </View>
+                    <View style={{ width: '100%', overflow: 'hidden', marginTop: 8, alignItems: 'center', justifyContent: 'center' }}>
+                        <TextTicker
+                            style={StyleSheet.flatten([typography.caption2, { color: colors.text, fontWeight: '600', textAlign: 'center', alignSelf: 'center' }])}
+                            duration={4000}
+                            loop
+                            bounce
+                            repeatSpacer={50}
+                            marqueeDelay={1000}
+                        >
+                            {t('home.signalPointing')}
+                        </TextTicker>
+                    </View>
                 </TouchableOpacity>
 
+                {/* Cek Cepat */}
                 <TouchableOpacity
-                    style={[styles.quickActionSmall, { backgroundColor: colors.card, borderColor: colors.border, borderWidth: 1 }]}
+                    style={[styles.smallAction, { backgroundColor: itemBg, borderColor: itemBorder }]}
                     onPress={onQuickCheck}
                     disabled={isRunningCheck}
+                    activeOpacity={0.7}
                 >
                     {isRunningCheck ? (
                         <BouncingDots size="small" color={colors.primary} />
                     ) : (
                         <>
-                            <MaterialIcons name="perm-scan-wifi" size={22} color={colors.primary} />
-                            <TextTicker
-                                style={StyleSheet.flatten([typography.caption2, { color: colors.text, fontWeight: '500', marginTop: 4, textAlign: 'center' }])}
-                                duration={6000}
-                                loop
-                                bounce
-                                repeatSpacer={50}
-                                marqueeDelay={1000}
-                            >
-                                {t('home.quickCheck')}
-                            </TextTicker>
+                            <View style={[styles.smallIconCircle, { backgroundColor: 'rgba(234, 179, 8, 0.15)' }]}>
+                                <MaterialIcons name="flash-on" size={20} color="#eab308" />
+                            </View>
+                            <View style={{ width: '100%', overflow: 'hidden', marginTop: 8, alignItems: 'center', justifyContent: 'center' }}>
+                                <TextTicker
+                                    style={StyleSheet.flatten([typography.caption2, { color: colors.text, fontWeight: '600', textAlign: 'center', alignSelf: 'center' }])}
+                                    duration={4000}
+                                    loop
+                                    bounce
+                                    repeatSpacer={50}
+                                    marqueeDelay={1000}
+                                >
+                                    {t('home.quickCheck')}
+                                </TextTicker>
+                            </View>
                         </>
                     )}
                 </TouchableOpacity>
 
+                {/* Speed Test */}
                 <TouchableOpacity
-                    style={[styles.quickActionSmall, { backgroundColor: colors.card, borderColor: colors.border, borderWidth: 1 }]}
+                    style={[styles.smallAction, { backgroundColor: itemBg, borderColor: itemBorder }]}
                     onPress={onSpeedtest}
+                    activeOpacity={0.7}
                 >
-                    <MaterialIcons name="speed" size={22} color={colors.primary} />
-                    <TextTicker
-                        style={StyleSheet.flatten([typography.caption2, { color: colors.text, fontWeight: '500', marginTop: 4, textAlign: 'center' }])}
-                        duration={6000}
-                        loop
-                        bounce
-                        repeatSpacer={50}
-                        marqueeDelay={1000}
-                    >
-                        {t('home.speedtest')}
-                    </TextTicker>
+                    <View style={[styles.smallIconCircle, { backgroundColor: 'rgba(244, 63, 94, 0.15)' }]}>
+                        <MaterialIcons name="speed" size={20} color="#f43f5e" />
+                    </View>
+                    <View style={{ width: '100%', overflow: 'hidden', marginTop: 8, alignItems: 'center', justifyContent: 'center' }}>
+                        <TextTicker
+                            style={StyleSheet.flatten([typography.caption2, { color: colors.text, fontWeight: '600', textAlign: 'center', alignSelf: 'center' }])}
+                            duration={4000}
+                            loop
+                            bounce
+                            repeatSpacer={50}
+                            marqueeDelay={1000}
+                        >
+                            {t('home.speedtest')}
+                        </TextTicker>
+                    </View>
                 </TouchableOpacity>
             </View>
         </CollapsibleCard>
@@ -221,37 +261,57 @@ export function QuickActionsCard({
 }
 
 const styles = StyleSheet.create({
-    quickActionsRow: {
-        flexDirection: 'row',
-        marginBottom: 8,
-        gap: 8,
+    cardTitle: {
+        fontSize: 12,
+        fontWeight: '600',
+        letterSpacing: 0.5,
+        color: '#8e8e93',
     },
-    quickActionLarge: {
-        flex: 1,
+    topRow: {
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        marginBottom: 12,
+    },
+    largeAction: {
+        width: '48.5%',
         flexDirection: 'row',
         alignItems: 'center',
         padding: 12,
-        borderRadius: 12,
+        borderRadius: 16,
+        borderWidth: 1,
     },
-    quickActionIcon: {
-        width: 40,
-        height: 40,
+    largeIconContainer: {
+        width: 36,
+        height: 36,
         borderRadius: 10,
         justifyContent: 'center',
         alignItems: 'center',
         marginRight: 10,
     },
-    quickActionLargeContent: {
+    largeActionContent: {
         flex: 1,
+        overflow: 'hidden',
+        marginRight: 4,
     },
-    quickActionSmall: {
-        flex: 1,
+    bottomRow: {
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+    },
+    smallAction: {
+        width: '23.2%',
+        borderRadius: 16,
+        borderWidth: 1,
         paddingVertical: 12,
-        paddingHorizontal: 6,
-        borderRadius: 12,
+        paddingHorizontal: 4,
+        alignItems: 'center',
+        justifyContent: 'center',
+    },
+    smallIconCircle: {
+        width: 36,
+        height: 36,
+        borderRadius: 18,
         justifyContent: 'center',
         alignItems: 'center',
-        minHeight: 70,
     },
 });
 

--- a/src/components/home/SignalInfoCard.tsx
+++ b/src/components/home/SignalInfoCard.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
-import { Text } from 'react-native';
+import { View, Text, StyleSheet } from 'react-native';
 import { useTheme } from '@/theme';
-import { CollapsibleCard, SignalCard } from '@/components';
+import { CollapsibleCard } from '@/components';
 import {
     getSignalStrength,
     getSignalIconFromModemStatus,
     getSignalStrengthFromIcon,
-    getLteBandInfo,
 } from '@/utils/helpers';
 
 interface SignalInfoCardProps {
@@ -44,13 +43,13 @@ const getSignalQuality = (
 };
 
 export function SignalInfoCard({ t, signalInfo, modemStatus }: SignalInfoCardProps) {
-    const { colors, typography, spacing } = useTheme();
+    const { colors, typography, spacing, isDark } = useTheme();
 
     const hasSignalData = (signalInfo && (signalInfo.rssi || signalInfo.rsrp)) || modemStatus?.signalIcon;
 
     if (!hasSignalData) {
         return (
-            <CollapsibleCard title={t('home.signalInfo')}>
+            <CollapsibleCard title={t('home.signalInfo').toUpperCase()} titleStyle={styles.cardTitle}>
                 <Text style={[typography.body, { color: colors.textSecondary, textAlign: 'center', padding: spacing.lg }]}>
                     {t('home.noSignalAvailable')}{'\n'}
                     {t('home.checkLogin')}
@@ -69,46 +68,219 @@ export function SignalInfoCard({ t, signalInfo, modemStatus }: SignalInfoCardPro
         return t(`home.signal${fallbackStrength.charAt(0).toUpperCase()}${fallbackStrength.slice(1)}`);
     };
 
+    const getStrengthColor = (strength: string): string => {
+        switch (strength) {
+            case 'excellent':
+            case 'good':
+                return colors.success;
+            case 'fair':
+                return colors.warning;
+            default:
+                return colors.error;
+        }
+    };
+
+    const getStrengthBgColor = (strength: string): string => {
+        switch (strength) {
+            case 'excellent':
+            case 'good':
+                return 'rgba(34, 197, 94, 0.1)';
+            case 'fair':
+                return 'rgba(234, 179, 8, 0.1)';
+            default:
+                return 'rgba(239, 68, 68, 0.1)';
+        }
+    };
+
+    const strength = getSignalStrength(signalInfo?.rssi, signalInfo?.rsrp);
+    const strengthLabel = getStrengthBadge();
+    const badgeColor = getStrengthColor(strength);
+    const badgeBg = getStrengthBgColor(strength);
+
+    const headerRightBadge = (
+        <View style={[
+            styles.headerStatusBadge,
+            {
+                borderColor: badgeColor,
+                backgroundColor: badgeBg,
+            }
+        ]}>
+            <Text style={[
+                typography.caption1,
+                {
+                    color: badgeColor,
+                    fontWeight: '700',
+                }
+            ]}>
+                {strengthLabel}
+            </Text>
+        </View>
+    );
+
+    const parseSignalValue = (val: string): number => {
+        if (!val) return NaN;
+        const cleaned = val.replace(/[^0-9.-]/g, '');
+        const num = parseFloat(cleaned);
+        return isNaN(num) ? NaN : num;
+    };
+
+    const cleanDisplayValue = (val: string) => {
+        if (!val) return '';
+        return val.replace(/(dBm|dB|dBi)/gi, '').trim();
+    };
+
     const metrics = [
         ...(signalInfo?.rssi ? [{
             label: 'RSSI',
             value: signalInfo.rssi,
             unit: 'dBm',
-            quality: getSignalQuality(parseFloat(signalInfo.rssi), { excellent: -65, good: -75, fair: -85, poor: -95 }, true),
+            quality: getSignalQuality(parseSignalValue(signalInfo.rssi), { excellent: -65, good: -75, fair: -85, poor: -95 }, true),
         }] : []),
         ...(signalInfo?.rsrp ? [{
             label: 'RSRP',
             value: signalInfo.rsrp,
             unit: 'dBm',
-            quality: getSignalQuality(parseFloat(signalInfo.rsrp), { excellent: -80, good: -90, fair: -100, poor: -110 }, true),
+            quality: getSignalQuality(parseSignalValue(signalInfo.rsrp), { excellent: -80, good: -90, fair: -100, poor: -110 }, true),
         }] : []),
         ...(signalInfo?.rsrq ? [{
             label: 'RSRQ',
             value: signalInfo.rsrq,
             unit: 'dB',
-            quality: getSignalQuality(parseFloat(signalInfo.rsrq), { excellent: -5, good: -9, fair: -12, poor: -15 }, true),
+            quality: getSignalQuality(parseSignalValue(signalInfo.rsrq), { excellent: -5, good: -9, fair: -12, poor: -15 }, true),
         }] : []),
         ...(signalInfo?.sinr ? [{
             label: 'SINR',
             value: signalInfo.sinr,
             unit: 'dB',
-            quality: getSignalQuality(parseFloat(signalInfo.sinr), { excellent: 20, good: 13, fair: 6, poor: 0 }, false),
+            quality: getSignalQuality(parseSignalValue(signalInfo.sinr), { excellent: 20, good: 13, fair: 6, poor: 0 }, false),
         }] : []),
     ];
 
+    const getQualityColor = (quality: string): string => {
+        switch (quality) {
+            case 'excellent': return '#22c55e';
+            case 'good': return '#a3e635';
+            case 'fair': return '#eab308';
+            case 'poor': return '#ef4444';
+            default: return '#8e8e93';
+        }
+    };
+
+    const getQualityWidth = (quality: string): number => {
+        switch (quality) {
+            case 'excellent': return 100;
+            case 'good': return 75;
+            case 'fair': return 50;
+            case 'poor': return 25;
+            default: return 10;
+        }
+    };
+
+    const gridItemBg = isDark ? 'rgba(255, 255, 255, 0.03)' : 'rgba(0, 0, 0, 0.02)';
+    const gridItemBorder = isDark ? 'rgba(255, 255, 255, 0.06)' : 'rgba(0, 0, 0, 0.05)';
+
     return (
-        <CollapsibleCard title={t('home.signalInfo')}>
-            <SignalCard
-                title={t('home.signalStrength')}
-                badge={getStrengthBadge()}
-                color="blue"
-                icon="signal-cellular-alt"
-                metrics={metrics}
-                band={signalInfo?.band ? getLteBandInfo(signalInfo.band) : undefined}
-                cellId={signalInfo?.cellId}
-            />
+        <CollapsibleCard
+            title={t('home.signalInfo').toUpperCase()}
+            headerRight={headerRightBadge}
+            titleStyle={styles.cardTitle}
+        >
+            <View style={styles.gridContainer}>
+                {metrics.map((metric, index) => {
+                    const qualityColor = getQualityColor(metric.quality);
+                    const filledWidth = getQualityWidth(metric.quality);
+                    return (
+                        <View
+                            key={index}
+                            style={[
+                                styles.gridItem,
+                                {
+                                    backgroundColor: gridItemBg,
+                                    borderColor: gridItemBorder
+                                }
+                            ]}
+                        >
+                            <Text style={styles.gridItemLabel}>{metric.label}</Text>
+                            <Text style={[styles.gridItemValue, { color: qualityColor }]}>
+                                {cleanDisplayValue(metric.value)}
+                                <Text style={{ fontSize: 16, fontWeight: '600' }}> {metric.unit}</Text>
+                            </Text>
+                            <View style={[styles.progressBarContainer, { backgroundColor: isDark ? 'rgba(255,255,255,0.05)' : 'rgba(0,0,0,0.05)' }]}>
+                                <View style={[styles.progressBarFill, { width: `${filledWidth}%`, backgroundColor: qualityColor }]} />
+                            </View>
+                            <View style={styles.scaleRow}>
+                                <Text style={styles.scaleText}>{t('home.signalWeak')}</Text>
+                                <Text style={styles.scaleText}>{t('home.signalPerfect')}</Text>
+                            </View>
+                        </View>
+                    );
+                })}
+            </View>
         </CollapsibleCard>
     );
 }
+
+const styles = StyleSheet.create({
+    cardTitle: {
+        fontSize: 12,
+        fontWeight: '600',
+        letterSpacing: 0.5,
+        color: '#8e8e93',
+    },
+    headerStatusBadge: {
+        borderWidth: 1,
+        borderRadius: 20,
+        paddingHorizontal: 12,
+        paddingVertical: 4,
+        alignItems: 'center',
+        justifyContent: 'center',
+    },
+    gridContainer: {
+        flexDirection: 'row',
+        flexWrap: 'wrap',
+        justifyContent: 'space-between',
+    },
+    gridItem: {
+        width: '48.5%',
+        borderRadius: 16,
+        padding: 16,
+        borderWidth: 1,
+        marginBottom: 12,
+    },
+    gridItemLabel: {
+        fontSize: 10,
+        fontWeight: '600',
+        color: '#8e8e93',
+        letterSpacing: 0.5,
+        marginBottom: 8,
+    },
+    gridItemValue: {
+        fontSize: 24,
+        fontWeight: '700',
+        fontFamily: 'monospace',
+        textAlign: 'center',
+    },
+    progressBarContainer: {
+        height: 6,
+        width: '100%',
+        borderRadius: 3,
+        marginTop: 12,
+        overflow: 'hidden',
+    },
+    progressBarFill: {
+        height: '100%',
+        borderRadius: 3,
+    },
+    scaleRow: {
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        marginTop: 6,
+    },
+    scaleText: {
+        fontSize: 9,
+        fontWeight: '500',
+        color: '#8e8e93',
+    },
+});
 
 export default SignalInfoCard;

--- a/src/hooks/useModemData.ts
+++ b/src/hooks/useModemData.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState, useCallback, useRef } from 'react';
+import { AppState } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useAuthStore } from '@/stores/auth.store';
 import { useModemStore } from '@/stores/modem.store';
@@ -155,11 +156,15 @@ export function useModemData({ t, durationUnits }: UseModemDataOptions): UseMode
             checkDebugReminder();
 
             const fastIntervalId = setInterval(() => {
-                loadTrafficOnly(service);
+                if (AppState.currentState === 'active') {
+                    loadTrafficOnly(service);
+                }
             }, 1000);
 
             const slowIntervalId = setInterval(() => {
-                loadDataSilent(service);
+                if (AppState.currentState === 'active') {
+                    loadDataSilent(service);
+                }
             }, 5000);
 
             return () => {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -127,6 +127,13 @@
     "reportIssueMessage": "Choose how you would like to report the issue"
   },
   "home": {
+    "provider": "Provider",
+    "networkSpeed": "Network Speed",
+    "powerSource": "Power Source",
+    "frequencyBand": "Frequency / Band",
+    "bandwidth": "Bandwidth",
+    "acPower": "AC Power",
+    "battery": "Battery",
     "connectionStatus": "Connection Status",
     "connected": "Connected",
     "disconnected": "Disconnected",
@@ -190,6 +197,8 @@
     "signalFair": "Fair",
     "signalPoor": "Poor",
     "signalVeryPoor": "Very Poor",
+    "signalWeak": "Weak",
+    "signalPerfect": "Perfect",
     "statusConnected": "Connected",
     "statusDisconnected": "Disconnected",
     "statusConnecting": "Connecting",

--- a/src/i18n/id.json
+++ b/src/i18n/id.json
@@ -127,6 +127,13 @@
     "reportIssueMessage": "Pilih cara Anda ingin melaporkan masalah"
   },
   "home": {
+    "provider": "Provider",
+    "networkSpeed": "Kecepatan Jaringan",
+    "powerSource": "Aliran Daya",
+    "frequencyBand": "Frekuensi / Band",
+    "bandwidth": "Bandwidth",
+    "acPower": "Daya AC",
+    "battery": "Baterai",
     "connectionStatus": "Status Koneksi",
     "connected": "Terhubung",
     "disconnected": "Terputus",
@@ -190,6 +197,8 @@
     "signalFair": "Cukup",
     "signalPoor": "Lemah",
     "signalVeryPoor": "Sangat Lemah",
+    "signalWeak": "Lemah",
+    "signalPerfect": "Sempurna",
     "statusConnected": "Terhubung",
     "statusDisconnected": "Terputus",
     "statusConnecting": "Menyambung",

--- a/src/widget/WidgetUpdater.tsx
+++ b/src/widget/WidgetUpdater.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { requestWidgetUpdate, requestWidgetUpdateById } from 'react-native-android-widget';
+import { requestWidgetUpdate, requestWidgetUpdateById, getWidgetInfo } from 'react-native-android-widget';
 import { AppState } from 'react-native';
 import type { AppStateStatus } from 'react-native';
 import { ModemStatusWidget } from './ModemStatusWidget';
@@ -92,18 +92,25 @@ export function startRealtimeWidgetUpdates(): () => void {
     updateCount = 0;
     isUpdating = false;
 
-    updateWidgetWithFullData();
-
-    speedIntervalId = setInterval(() => {
-        if (AppState.currentState === 'active') {
-            updateWidgetWithSpeed();
+    getWidgetInfo(WIDGET_NAME).then((widgets) => {
+        if (widgets.length === 0) {
+            return;
         }
-    }, SPEED_UPDATE_INTERVAL);
 
-    fullDataIntervalId = setInterval(() => {
         updateWidgetWithFullData();
-    }, FULL_UPDATE_INTERVAL);
 
+        speedIntervalId = setInterval(() => {
+            if (AppState.currentState === 'active') {
+                updateWidgetWithSpeed();
+            }
+        }, SPEED_UPDATE_INTERVAL);
+
+        fullDataIntervalId = setInterval(() => {
+            if (AppState.currentState === 'active') {
+                updateWidgetWithFullData();
+            }
+        }, FULL_UPDATE_INTERVAL);
+    }).catch(() => {});
 
     return stopRealtimeWidgetUpdates;
 }


### PR DESCRIPTION
feat(home): redesign dashboard cards and optimize battery and ad flows

- Redesign ConnectionStatusCard, QuickActionsCard, and SignalInfoCard grid
- Center-align text in QuickActions grid and center SignalInfoCard values
- Implement background duration throttle (15s) and cooldown (60s) for App Open Ads
- Relocate quick check interstitial ad to trigger after results modal is dismissed
- Restrict background update intervals across tabs to save battery when app is inactive
- Only run widget updating loops if getWidgetInfo detects active widgets on screen
- Adjust AdBanner ad-blocker fallback layouts, paddings, and icon sizes
- Localize all status labels and scales in en.json and id.json
