### PR TITLE
refactor(hooks): extract business logic from screens to custom hooks

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -69,7 +69,6 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "App version: $VERSION"
 
-      # ⬇️ BARU: set versionCode unik untuk arm64-v8a (suffix 2)
       - name: Set version code
         run: echo "ANDROID_VERSION_CODE=$(( ${{ github.run_number }} * 10 + 2 ))" >> $GITHUB_ENV
 
@@ -139,7 +138,6 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "App version: $VERSION"
 
-      # ⬇️ BARU: set versionCode unik untuk armeabi-v7a (suffix 1)
       - name: Set version code
         run: echo "ANDROID_VERSION_CODE=$(( ${{ github.run_number }} * 10 + 1 ))" >> $GITHUB_ENV
 
@@ -209,7 +207,6 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "App version: $VERSION"
 
-      # ⬇️ BARU: set versionCode unik untuk universal (suffix 3)
       - name: Set version code
         run: echo "ANDROID_VERSION_CODE=$(( ${{ github.run_number }} * 10 + 3 ))" >> $GITHUB_ENV
 
@@ -269,7 +266,7 @@ jobs:
             COMMITS=$(git log --pretty=format:"%H" 2>/dev/null || echo "")
           fi
 
-          echo "## What's Changed" > release_notes.md
+          echo "## What's Changed — v${{ needs.build-arm64.outputs.version }}" > release_notes.md
           echo "" >> release_notes.md
 
           PR_FOUND=false
@@ -325,79 +322,47 @@ jobs:
           name: Huawei Manager v${{ needs.build-arm64.outputs.version }}
           body: |
             > [!WARNING]
-            > **🇬🇧 EN** 
-            > **Files are available in the `Assets` section below 👇**
             >
-            > **🇮🇩 ID**
-            > **File download berada di bagian `Assets` di bawah 👇**
-
-            ## Huawei Manager v${{ needs.build-arm64.outputs.version }}
-
-            ## 📥 Quick Download
-
-            > **arm64-v8a**: Untuk Android 64-bit (Rekomendasi) → [Link Download](https://github.com/alrescha79-cmd/huawei-manager-mobile/releases/download/v${{ needs.build-arm64.outputs.version }}/huawei-manager-arm64-v8a.apk)
+            > 🇬🇧 **Files are available in the `Assets` section below** 👇
             > 
-            > **armeabi-v7a**: Untuk Android 32-bit (Ukuran lebih kecil) → [Link Download](https://github.com/alrescha79-cmd/huawei-manager-mobile/releases/download/v${{ needs.build-arm64.outputs.version }}/huawei-manager-armeabi-v7a.apk)
-            >
-            > **universal**: Untuk semua perangkat (Ukuran lebih besar) → [Link Download](https://github.com/alrescha79-cmd/huawei-manager-mobile/releases/download/v${{ needs.build-arm64.outputs.version }}/huawei-manager-universal.apk)
+            > 🇮🇩 **File download berada di bagian `Assets` di bawah** 👇
+
+            ---
+
+            # Huawei Manager v${{ needs.build-arm64.outputs.version }}
+
+            ## 📥 Download Cepat
+
+            | Versi | Cocok Untuk | (MB) | Link |
+            |-------|-------------|--------|------|
+            | **arm64-v8a** | HP Android 64-bit / terbaru | 38 | [Download](https://github.com/alrescha79-cmd/huawei-manager-mobile/releases/download/v${{ needs.build-arm64.outputs.version }}/huawei-manager-arm64-v8a.apk) |
+            | **armeabi-v7a** | HP Android 32-bit / lama | 33 | [Download](https://github.com/alrescha79-cmd/huawei-manager-mobile/releases/download/v${{ needs.build-arm64.outputs.version }}/huawei-manager-armeabi-v7a.apk) |
+            | **universal** | Semua perangkat | 88 | [Download](https://github.com/alrescha79-cmd/huawei-manager-mobile/releases/download/v${{ needs.build-arm64.outputs.version }}/huawei-manager-universal.apk) |
+
+            > 💡 **Tidak tahu pilih yang mana?** Coba **arm64-v8a** dulu. Jika gagal install, gunakan **universal**.
+
+            --- 
+
+            ## 🔧 Cara Install
+
+            1. Download APK sesuai tabel di atas
+            2. Buka **Pengaturan → Keamanan → Aktifkan "Instal dari sumber tidak dikenal"**
+            3. Buka file APK yang sudah diunduh dan ikuti instruksi install
+
+            ---
+
+            ## 📌 Preview
+
+            <img width="1080" height="1350" alt="release" src="https://github.com/user-attachments/assets/df4972fd-1505-444c-8d15-c9d3f08c9e5d" />
+
+            ---
 
             ${{ steps.release_notes.outputs.notes }}
 
             ---
 
-            ### 📄 File Descriptions / Deskripsi File
-
-            #### 🇺🇸 EN (English)
-            * **huawei-manager-arm64-v8a.apk**
-              * Target: Modern & High-end devices (64-bit)
-              * Recommended for most Android phones released after 2016
-              * ✅ Better performance
-
-            * **huawei-manager-armeabi-v7a.apk**
-              * Target: Older & Low-end devices (32-bit)
-              * Use this if arm64 version fails to install
-              * ✅ Smaller file size
-
-            * **huawei-manager-universal.apk**
-              * Target: All devices
-              * Contains libraries for all architectures
-              * ⚠️ Larger file size, use only if you are unsure which one to pick
-
-            #### 🇮🇩 ID (Bahasa Indonesia)
-            * **huawei-manager-arm64-v8a.apk**
-              * Target: Perangkat Modern & High-end (64-bit)
-              * Direkomendasikan untuk sebagian besar HP Android keluaran di atas 2016
-              * ✅ Performa lebih baik
-
-            * **huawei-manager-armeabi-v7a.apk**
-              * Target: Perangkat Lama & Low-end (32-bit)
-              * Gunakan ini jika versi arm64 gagal diinstall
-              * ✅ Ukuran file lebih kecil
-
-            * **huawei-manager-universal.apk**
-              * Target: Semua perangkat
-              * Berisi library untuk semua arsitektur
-              * ⚠️ Ukuran file lebih besar, gunakan hanya jika Anda ragu memilih versi
-
-            ### 🔧 Installation / Instalasi
-
-            #### 🇺🇸 English
-            1. Download the APK suitable for your device (arm64 recommended).
-            2. Enable "Install from unknown sources" in your Android Settings.
-            3. Open the downloaded file to install.
-
-            #### 🇮🇩 Bahasa Indonesia
-            1. Download APK yang sesuai dengan perangkat Anda (arm64 direkomendasikan).
-            2. Aktifkan "Install from unknown sources" (Instal dari sumber tidak dikenal) di Pengaturan.
-            3. Buka file APK untuk menginstall.
-
-            ### 💡 Notes / Catatan
-
-            > **EN**
-            > We appreciate your understanding and feedback to help improve Huawei Manager.
-            >
-            > **ID**
-            > Terima kasih atas pengertian dan masukan Anda untuk membantu pengembangan Huawei Manager.
+            Terima kasih sudah menggunakan **Huawei Manager Mobile**! 🙏
+            Temukan masalah? Laporkan di [GitHub Issues](https://github.com/alrescha79-cmd/huawei-manager-mobile/issues).
           files: apks/*.apk
           draft: false
           prerelease: ${{ github.event.inputs.release_type == 'pre-release' }}
@@ -412,79 +377,47 @@ jobs:
           name: Huawei Manager ${{ github.event.inputs.version }}
           body: |
             > [!WARNING]
-            > **🇬🇧 EN** 
-            > **Files are available in the `Assets` section below 👇**
             >
-            > **🇮🇩 ID**
-            > **File download berada di bagian `Assets` di bawah 👇**
-
-            ## Huawei Manager ${{ github.event.inputs.version }}
-
-            ## 📥 Quick Download
-
-            > **arm64-v8a**: Untuk Android 64-bit (Rekomendasi) → [Link Download](https://github.com/alrescha79-cmd/huawei-manager-mobile/releases/download/${{ github.event.inputs.version }}/huawei-manager-arm64-v8a.apk)
+            > 🇬🇧 **Files are available in the `Assets` section below** 👇
             > 
-            > **armeabi-v7a**: Untuk Android 32-bit (Ukuran lebih kecil) → [Link Download](https://github.com/alrescha79-cmd/huawei-manager-mobile/releases/download/${{ github.event.inputs.version }}/huawei-manager-armeabi-v7a.apk)
-            >
-            > **universal**: Untuk semua perangkat (Ukuran lebih besar) → [Link Download](https://github.com/alrescha79-cmd/huawei-manager-mobile/releases/download/${{ github.event.inputs.version }}/huawei-manager-universal.apk)
+            > 🇮🇩 **File download berada di bagian `Assets` di bawah** 👇
+
+            ---
+
+            # Huawei Manager ${{ github.event.inputs.version }}
+
+            ## 📥 Download Cepat
+
+            | Versi | Cocok Untuk | (MB) | Link |
+            |-------|-------------|--------|------|
+            | **arm64-v8a** | HP Android 64-bit / terbaru | 38 | [Download](https://github.com/alrescha79-cmd/huawei-manager-mobile/releases/download/${{ github.event.inputs.version }}/huawei-manager-arm64-v8a.apk) |
+            | **armeabi-v7a** | HP Android 32-bit / lama | 33 | [Download](https://github.com/alrescha79-cmd/huawei-manager-mobile/releases/download/${{ github.event.inputs.version }}/huawei-manager-armeabi-v7a.apk) |
+            | **universal** | Semua perangkat | 88 | [Download](https://github.com/alrescha79-cmd/huawei-manager-mobile/releases/download/${{ github.event.inputs.version }}/huawei-manager-universal.apk) |
+
+            > 💡 **Tidak tahu pilih yang mana?** Coba **arm64-v8a** dulu. Jika gagal install, gunakan **universal**.
+
+            --- 
+
+            ## 🔧 Cara Install
+
+            1. Download APK sesuai tabel di atas
+            2. Buka **Pengaturan → Keamanan → Aktifkan "Instal dari sumber tidak dikenal"**
+            3. Buka file APK yang sudah diunduh dan ikuti instruksi install
+
+            ---
+
+            ## 📌 Preview
+
+            <img width="1080" height="1350" alt="release" src="https://github.com/user-attachments/assets/df4972fd-1505-444c-8d15-c9d3f08c9e5d" />
+
+            ---
 
             ${{ steps.release_notes.outputs.notes }}
 
             ---
 
-            ### 📄 File Descriptions / Deskripsi File
-
-            #### 🇺🇸 EN (English)
-            * **huawei-manager-arm64-v8a.apk**
-              * Target: Modern & High-end devices (64-bit)
-              * Recommended for most Android phones released after 2016
-              * ✅ Better performance
-
-            * **huawei-manager-armeabi-v7a.apk**
-              * Target: Older & Low-end devices (32-bit)
-              * Use this if arm64 version fails to install
-              * ✅ Smaller file size
-
-            * **huawei-manager-universal.apk**
-              * Target: All devices
-              * Contains libraries for all architectures
-              * ⚠️ Larger file size, use only if you are unsure which one to pick
-
-            #### 🇮🇩 ID (Bahasa Indonesia)
-            * **huawei-manager-arm64-v8a.apk**
-              * Target: Perangkat Modern & High-end (64-bit)
-              * Direkomendasikan untuk sebagian besar HP Android keluaran di atas 2016
-              * ✅ Performa lebih baik
-
-            * **huawei-manager-armeabi-v7a.apk**
-              * Target: Perangkat Lama & Low-end (32-bit)
-              * Gunakan ini jika versi arm64 gagal diinstall
-              * ✅ Ukuran file lebih kecil
-
-            * **huawei-manager-universal.apk**
-              * Target: Semua perangkat
-              * Berisi library untuk semua arsitektur
-              * ⚠️ Ukuran file lebih besar, gunakan hanya jika Anda ragu memilih versi
-
-            ### 🔧 Installation / Instalasi
-
-            #### 🇺🇸 English
-            1. Download the APK suitable for your device (arm64 recommended).
-            2. Enable "Install from unknown sources" in your Android Settings.
-            3. Open the downloaded file to install.
-
-            #### 🇮🇩 Bahasa Indonesia
-            1. Download APK yang sesuai dengan perangkat Anda (arm64 direkomendasikan).
-            2. Aktifkan "Install from unknown sources" (Instal dari sumber tidak dikenal) di Pengaturan.
-            3. Buka file APK untuk menginstall.
-
-            ### 💡 Notes / Catatan
-
-            > **EN**
-            > We appreciate your understanding and feedback to help improve Huawei Manager.
-            >
-            > **ID**
-            > Terima kasih atas pengertian dan masukan Anda untuk membantu pengembangan Huawei Manager.
+            Terima kasih sudah menggunakan **Huawei Manager Mobile**! 🙏
+            Temukan masalah? Laporkan di [GitHub Issues](https://github.com/alrescha79-cmd/huawei-manager-mobile/issues).
           files: apks/*.apk
           draft: false
           prerelease: ${{ github.event.inputs.release_type == 'pre-release' }}

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -143,7 +143,7 @@ jobs:
             | **Commit** | `${{ steps.get_info.outputs.short_sha }}` |
             
             > ⚠️ This is a test build, not for production use.
-            > 🗑️ This release will be deleted after testing.
+            > Silakan unduh jika ingin mencoba versi terbaru sebelum rilis resmi.
           prerelease: true
           files: ${{ steps.rename_apk.outputs.apk_filename }}
         env:

--- a/src/app/(tabs)/home.tsx
+++ b/src/app/(tabs)/home.tsx
@@ -146,21 +146,6 @@ export default function HomeScreen() {
             />
           }
         >
-          {/* <View style={styles.header}>
-            {!hasValidData && (
-              <TouchableOpacity
-                onPress={homeAuth.handleReLogin}
-                style={[styles.reLoginButton, { backgroundColor: colors.error }]}
-              >
-                <Text style={[typography.caption1, { color: '#FFFFFF' }]}>
-                  {t('home.reLogin')}
-                </Text>
-              </TouchableOpacity>
-            )}
-          </View> */}
-
-
-
           {!signalInfo && homeData.isRefreshing && (
             <>
               <ConnectionStatusSkeleton />

--- a/src/app/(tabs)/settings/lan.tsx
+++ b/src/app/(tabs)/settings/lan.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import {
     View,
     Text,
@@ -9,13 +9,10 @@ import {
 } from 'react-native';
 import { MaterialIcons } from '@expo/vector-icons';
 import { useTheme } from '@/theme';
-import { useAuthStore } from '@/stores/auth.store';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { NetworkSettingsService } from '@/services/network.settings.service';
 import { useTranslation } from '@/i18n';
-import { ThemedAlertHelper, Button, SelectionModal, MeshGradientBackground, ThemedSwitch, BouncingDots, AnimatedScreen, AdNative } from '@/components';
+import { Button, SelectionModal, MeshGradientBackground, ThemedSwitch, BouncingDots, AnimatedScreen, AdNative } from '@/components';
 import { InfoRow, SettingsSection, SettingsItem, PageHeader, ApnModal } from '@/components/settings';
-import { showInterstitial } from '@/services/ad.service';
+import { useLanSettings } from '@/hooks/settings';
 
 const ETHERNET_MODES = [
     { value: 'auto', labelKey: 'networkSettings.modeAuto' },
@@ -26,222 +23,20 @@ const ETHERNET_MODES = [
 ];
 
 export default function LanSettingsScreen() {
-    const { colors, typography, spacing } = useTheme();
+    const { colors, typography } = useTheme();
     const { t } = useTranslation();
-    const { credentials } = useAuthStore();
-    const insets = useSafeAreaInsets();
 
-    const [networkSettingsService, setNetworkSettingsService] = useState<NetworkSettingsService | null>(null);
-
-    // Ethernet
-    const [ethernetMode, setEthernetMode] = useState<'auto' | 'lan_only' | 'pppoe' | 'dynamic_ip' | 'pppoe_dynamic'>('auto');
-    const [ethernetStatus, setEthernetStatus] = useState<any>({ connected: false });
-    const [isChangingEthernet, setIsChangingEthernet] = useState(false);
-    const [showEthernetModal, setShowEthernetModal] = useState(false);
-
-    // DHCP
-    const [dhcpSettings, setDhcpSettings] = useState({
-        dhcpIPAddress: '192.168.8.1',
-        dhcpLanNetmask: '255.255.255.0',
-        dhcpStatus: true,
-        dhcpStartIPAddress: '192.168.8.100',
-        dhcpEndIPAddress: '192.168.8.200',
-        dhcpLeaseTime: 86400,
-        dnsStatus: true,
-    });
-    const [isTogglingDhcp, setIsTogglingDhcp] = useState(false);
-    const [isSavingDhcp, setIsSavingDhcp] = useState(false);
-    const [showLeaseTimeDropdown, setShowLeaseTimeDropdown] = useState(false);
-
-    // APN
-    const [apnProfiles, setApnProfiles] = useState<any[]>([]);
-    const [activeApnProfileId, setActiveApnProfileId] = useState('');
-
-    // APN Modal
-    const [showApnModal, setShowApnModal] = useState(false);
-    const [editingApn, setEditingApn] = useState<any | null>(null);
-    const [isSavingApn, setIsSavingApn] = useState(false);
-
-    useEffect(() => {
-        if (credentials?.modemIp) {
-            const service = new NetworkSettingsService(credentials.modemIp);
-            setNetworkSettingsService(service);
-            loadEthernet(service);
-            loadDhcp(service);
-            loadApn(service);
-        }
-    }, [credentials]);
-
-    const loadEthernet = async (service: NetworkSettingsService) => {
-        try {
-            const settings = await service.getEthernetSettings();
-            setEthernetMode(settings.connectionMode);
-            setEthernetStatus(settings.status);
-        } catch (e) { }
-    };
-
-    const loadDhcp = async (service: NetworkSettingsService) => {
-        try {
-            const settings = await service.getDHCPSettings();
-            setDhcpSettings(settings);
-        } catch (e) { }
-    };
-
-    const loadApn = async (service: NetworkSettingsService) => {
-        try {
-            const profiles = await service.getAPNProfiles();
-            const activeId = await service.getActiveAPNProfile();
-            setActiveApnProfileId(activeId);
-            setApnProfiles(profiles.map(p => ({ ...p, isDefault: p.id === activeId })));
-        } catch (e) { }
-    };
-
-    // Ethernet Logic
-    const handleEthernetModeChange = async (mode: typeof ethernetMode) => {
-        if (!networkSettingsService || isChangingEthernet) return;
-
-        const changed = mode !== ethernetMode;
-
-        setIsChangingEthernet(true);
-        try {
-            await networkSettingsService.setEthernetConnectionMode(mode);
-            setEthernetMode(mode);
-            const settings = await networkSettingsService.getEthernetSettings();
-            setEthernetStatus(settings.status);
-            ThemedAlertHelper.alert(t('common.success'), t('networkSettings.profileSaved'));
-            if (changed) {
-                showInterstitial(() => { });
-            }
-        } catch (error) {
-            ThemedAlertHelper.alert(t('common.error'), t('common.error'));
-        } finally {
-            setIsChangingEthernet(false);
-        }
-    };
-
-    // DHCP Logic
-    const handleDHCPToggle = async (enabled: boolean) => {
-        if (!networkSettingsService || isTogglingDhcp) return;
-        setIsTogglingDhcp(true);
-        try {
-            await networkSettingsService.toggleDHCPServer(enabled);
-            setDhcpSettings(prev => ({ ...prev, dhcpStatus: enabled }));
-        } catch (error) {
-            ThemedAlertHelper.alert(t('common.error'), t('networkSettings.failedSaveDhcp'));
-        } finally {
-            setIsTogglingDhcp(false);
-        }
-    };
-
-    const handleSaveDHCPSettings = async () => {
-        if (!networkSettingsService || isSavingDhcp) return;
-        setIsSavingDhcp(true);
-        try {
-            await networkSettingsService.setDHCPSettings(dhcpSettings);
-            showInterstitial(() => {
-                ThemedAlertHelper.alert(t('common.success'), t('networkSettings.dhcpSaved'));
-            });
-        } catch (error) {
-            ThemedAlertHelper.alert(t('common.error'), t('networkSettings.failedSaveDhcp'));
-        } finally {
-            setIsSavingDhcp(false);
-        }
-    };
-
-    const getLeaseTimeLabel = (seconds: number): string => {
-        if (seconds <= 3600) return t('networkSettings.leaseTime1Hour');
-        if (seconds <= 43200) return t('networkSettings.leaseTime12Hours');
-        if (seconds <= 86400) return t('networkSettings.leaseTime1Day');
-        return t('networkSettings.leaseTime1Week');
-    };
-
-    // APN Logic
-    const openAddApnModal = () => {
-        setEditingApn(null);
-        setShowApnModal(true);
-    };
-
-    const openEditApnModal = (profile: any) => {
-        setEditingApn(profile);
-        setShowApnModal(true);
-    };
-
-    const handleSaveApnProfile = async (profileData: any) => {
-        if (!networkSettingsService || isSavingApn) return;
-        setIsSavingApn(true);
-        try {
-            const data = {
-                ...profileData,
-                readOnly: false,
-            };
-
-            if (editingApn) {
-                await networkSettingsService.updateAPNProfile({ id: editingApn.id, ...data });
-            } else {
-                await networkSettingsService.createAPNProfile(data);
-            }
-            setShowApnModal(false);
-            showInterstitial(() => {
-                ThemedAlertHelper.alert(t('common.success'), t('networkSettings.apnSaved'));
-            });
-            setTimeout(() => loadApn(networkSettingsService), 2000);
-        } catch (error) {
-            ThemedAlertHelper.alert(t('common.error'), t('common.error'));
-        } finally {
-            setIsSavingApn(false);
-        }
-    };
-
-    const handleDeleteApnProfile = (profileId: string) => {
-        const profile = apnProfiles.find(p => p.id === profileId);
-        const profileName = profile?.name || profileId;
-
-        ThemedAlertHelper.alert(
-            t('networkSettings.deleteProfile'),
-            t('networkSettings.deleteProfileConfirm', { name: profileName }),
-            [
-                { text: t('common.cancel'), style: 'cancel' },
-                {
-                    text: t('common.delete'),
-                    style: 'destructive',
-                    onPress: async () => {
-                        try {
-                            await networkSettingsService?.deleteAPNProfile(profileId);
-                            ThemedAlertHelper.alert(t('common.success'), t('networkSettings.apnDeleted'));
-                            if (networkSettingsService) loadApn(networkSettingsService);
-                        } catch (error) {
-                            ThemedAlertHelper.alert(t('common.error'), t('networkSettings.deleteApnFailed'));
-                        }
-                    },
-                },
-            ]
-        );
-    };
-
-    const handleSetDefaultApn = async (profileId: string) => {
-        const profile = apnProfiles.find(p => p.id === profileId);
-        const profileName = profile?.name || profileId;
-
-        ThemedAlertHelper.alert(
-            t('networkSettings.switchProfile'),
-            t('networkSettings.switchProfileConfirm', { name: profileName }),
-            [
-                { text: t('common.cancel'), style: 'cancel' },
-                {
-                    text: t('common.confirm'),
-                    onPress: async () => {
-                        try {
-                            await networkSettingsService?.setActiveAPNProfile(profileId);
-                            if (networkSettingsService) loadApn(networkSettingsService);
-                            ThemedAlertHelper.alert(t('common.success'), t('networkSettings.profileSwitched'));
-                        } catch (e) {
-                            ThemedAlertHelper.alert(t('common.error'), t('common.error'));
-                        }
-                    },
-                },
-            ]
-        );
-    };
+    const {
+        ethernetMode, ethernetStatus, isChangingEthernet,
+        showEthernetModal, setShowEthernetModal, handleEthernetModeChange,
+        dhcpSettings, setDhcpSettings, isTogglingDhcp, isSavingDhcp,
+        showLeaseTimeDropdown, setShowLeaseTimeDropdown,
+        handleDHCPToggle, handleSaveDHCPSettings, getLeaseTimeLabel,
+        apnProfiles, activeApnProfileId, showApnModal, setShowApnModal,
+        editingApn, setEditingApn, isSavingApn,
+        openAddApnModal, openEditApnModal, handleSaveApnProfile,
+        handleDeleteApnProfile, handleSetDefaultApn,
+    } = useLanSettings({ t });
 
     return (
         <AnimatedScreen noAnimation>
@@ -308,9 +103,9 @@ export default function LanSettingsScreen() {
                                         <TextInput
                                             style={[styles.smallInput, { color: colors.text, borderColor: colors.border }]}
                                             value={dhcpSettings.dhcpStartIPAddress.split('.').pop()}
-                                            onChangeText={t => {
+                                            onChangeText={val => {
                                                 const base = dhcpSettings.dhcpIPAddress.split('.').slice(0, 3).join('.');
-                                                setDhcpSettings(p => ({ ...p, dhcpStartIPAddress: `${base}.${t}` }))
+                                                setDhcpSettings(p => ({ ...p, dhcpStartIPAddress: `${base}.${val}` }))
                                             }}
                                             keyboardType="numeric"
                                         />
@@ -318,9 +113,9 @@ export default function LanSettingsScreen() {
                                         <TextInput
                                             style={[styles.smallInput, { color: colors.text, borderColor: colors.border }]}
                                             value={dhcpSettings.dhcpEndIPAddress.split('.').pop()}
-                                            onChangeText={t => {
+                                            onChangeText={val => {
                                                 const base = dhcpSettings.dhcpIPAddress.split('.').slice(0, 3).join('.');
-                                                setDhcpSettings(p => ({ ...p, dhcpEndIPAddress: `${base}.${t}` }))
+                                                setDhcpSettings(p => ({ ...p, dhcpEndIPAddress: `${base}.${val}` }))
                                             }}
                                             keyboardType="numeric"
                                         />
@@ -366,7 +161,7 @@ export default function LanSettingsScreen() {
 
                     <SettingsSection title={t('networkSettings.apnProfiles')}>
 
-                        {apnProfiles.map((profile, index) => (
+                        {apnProfiles.map((profile) => (
                             <SettingsItem
                                 key={profile.id}
                                 title={profile.name}
@@ -427,14 +222,6 @@ const styles = StyleSheet.create({
     container: {
         flex: 1,
     },
-    sectionWrapper: {
-        marginBottom: 24,
-        marginHorizontal: 16,
-    },
-    sectionContent: {
-        borderRadius: 12,
-        overflow: 'hidden',
-    },
     dropdownItem: {
         flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center',
         paddingVertical: 12, paddingHorizontal: 16, borderBottomWidth: StyleSheet.hairlineWidth,
@@ -443,9 +230,5 @@ const styles = StyleSheet.create({
     inputRow: { padding: 16 },
     smallInput: {
         borderWidth: 1, borderRadius: 4, width: 44, padding: 4, textAlign: 'center',
-    },
-    apnRow: {
-        flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center',
-        paddingVertical: 12, paddingHorizontal: 16, marginLeft: 16,
     },
 });

--- a/src/app/(tabs)/settings/mobile-network.tsx
+++ b/src/app/(tabs)/settings/mobile-network.tsx
@@ -1,21 +1,15 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import {
     StyleSheet,
     ScrollView,
-    ActivityIndicator,
     View,
-    TouchableOpacity,
     Text,
 } from 'react-native';
-import { useRouter } from 'expo-router';
 import { useTheme } from '@/theme';
-import { useAuthStore } from '@/stores/auth.store';
-import { ModemService } from '@/services/modem.service';
 import { useTranslation } from '@/i18n';
-import { BandSelectionModal, ThemedAlertHelper, getSelectedBandsDisplay, MonthlySettingsModal, SelectionModal, MeshGradientBackground, ThemedSwitch, BouncingDots, AnimatedScreen, SignalPointingModal, AdNative } from '@/components';
+import { BandSelectionModal, MonthlySettingsModal, SelectionModal, MeshGradientBackground, ThemedSwitch, BouncingDots, AnimatedScreen, SignalPointingModal, AdNative } from '@/components';
 import { SettingsSection, SettingsItem, PageHeader } from '@/components/settings';
-import { MaterialIcons } from '@expo/vector-icons';
-import { showInterstitial } from '@/services/ad.service';
+import { useMobileNetwork } from '@/hooks/settings';
 
 const NETWORK_MODES = [
     { value: '00', labelKey: 'settings.networkAuto' },
@@ -28,182 +22,20 @@ const NETWORK_MODES = [
 ];
 
 export default function MobileNetworkSettingsScreen() {
-    const { colors, typography } = useTheme();
+    const { colors } = useTheme();
     const { t } = useTranslation();
-    const { credentials } = useAuthStore();
-    const router = useRouter();
 
-    const [modemService, setModemService] = useState<ModemService | null>(null);
-
-    const [mobileDataEnabled, setMobileDataEnabled] = useState(false);
-    const [dataRoamingEnabled, setDataRoamingEnabled] = useState(false);
-    const [autoNetworkEnabled, setAutoNetworkEnabled] = useState(true);
-
-    const [isTogglingMobileData, setIsTogglingMobileData] = useState(false);
-    const [isTogglingRoaming, setIsTogglingRoaming] = useState(false);
-    const [isTogglingAutoNetwork, setIsTogglingAutoNetwork] = useState(false);
-
-    const [networkMode, setNetworkMode] = useState('00');
-    const [showNetworkModeModal, setShowNetworkModeModal] = useState(false);
-    const [isChangingNetwork, setIsChangingNetwork] = useState(false);
-
-    const [showBandModal, setShowBandModal] = useState(false);
-    const [selectedBandsDisplay, setSelectedBandsDisplay] = useState<string[]>([]);
-
-    const [showMonthlyModal, setShowMonthlyModal] = useState(false);
-    const [showSignalPointingModal, setShowSignalPointingModal] = useState(false);
-    const [monthlySettings, setMonthlySettings] = useState({
-        enabled: false,
-        startDay: 1,
-        dataLimit: 0,
-        dataLimitUnit: 'GB' as 'MB' | 'GB',
-        monthThreshold: 90,
-    });
-
-    useEffect(() => {
-        if (credentials?.modemIp) {
-            const service = new ModemService(credentials.modemIp);
-            setModemService(service);
-            loadSettings(service);
-        }
-    }, [credentials]);
-
-    const loadSettings = async (service: ModemService) => {
-        try {
-            const [mobileData, roaming, autoNetwork, netMode, bandSettings, mSettings] = await Promise.all([
-                service.getMobileDataStatus(),
-                service.getDataRoamingStatus(),
-                service.getAutoNetworkStatus(),
-                service.getNetworkMode(),
-                service.getBandSettings(),
-                service.getMonthlyDataSettings(),
-            ]);
-
-            setMobileDataEnabled(mobileData.isEnabled);
-            setDataRoamingEnabled(roaming);
-            setAutoNetworkEnabled(autoNetwork);
-            setNetworkMode(netMode);
-
-            if (bandSettings?.lteBand) {
-                setSelectedBandsDisplay(getSelectedBandsDisplay(bandSettings.lteBand));
-            }
-
-            setMonthlySettings({
-                enabled: mSettings.enabled,
-                startDay: mSettings.startDay,
-                dataLimit: mSettings.dataLimit,
-                dataLimitUnit: mSettings.dataLimitUnit,
-                monthThreshold: mSettings.monthThreshold,
-            });
-
-        } catch (error) {
-            console.error('Error loading mobile network settings:', error);
-        }
-    };
-
-    const handleSaveMonthlySettings = async (settings: any) => {
-        if (!modemService) return;
-        try {
-            await modemService.setMonthlyDataSettings(settings);
-            setMonthlySettings(settings);
-            showInterstitial(() => {
-                ThemedAlertHelper.alert(t('common.success'), t('home.monthlySettingsSaved'));
-            });
-        } catch (error) {
-            ThemedAlertHelper.alert(t('common.error'), t('home.failedSaveMonthlySettings'));
-        }
-    };
-
-    const handleToggleMobileData = async (value: boolean) => {
-        if (!modemService || isTogglingMobileData) return;
-
-        if (!value) {
-            ThemedAlertHelper.alert(
-                t('settings.mobileData'),
-                t('home.confirmDisableData'),
-                [
-                    { text: t('common.cancel'), style: 'cancel' },
-                    {
-                        text: t('common.turnOff'),
-                        style: 'destructive',
-                        onPress: () => executeToggleMobileData(value)
-                    }
-                ]
-            );
-        } else {
-            executeToggleMobileData(value);
-        }
-    };
-
-    const executeToggleMobileData = async (value: boolean) => {
-        if (!modemService) return;
-        setIsTogglingMobileData(true);
-        try {
-            await modemService.toggleMobileData(value);
-            setMobileDataEnabled(value);
-            showInterstitial(() => { });
-        } catch (error) {
-            ThemedAlertHelper.alert(t('common.error'), t('alerts.failedToggleData'));
-            setMobileDataEnabled(!value);
-        } finally {
-            setIsTogglingMobileData(false);
-        }
-    };
-
-    const handleToggleRoaming = async (value: boolean) => {
-        if (!modemService || isTogglingRoaming) return;
-        setIsTogglingRoaming(true);
-        try {
-            await modemService.setDataRoaming(value);
-            setDataRoamingEnabled(value);
-            showInterstitial(() => { });
-        } catch (error) {
-            ThemedAlertHelper.alert(t('common.error'), t('common.error'));
-            setDataRoamingEnabled(!value);
-        } finally {
-            setIsTogglingRoaming(false);
-        }
-    };
-
-    const handleToggleAutoNetwork = async (value: boolean) => {
-        if (!modemService || isTogglingAutoNetwork) return;
-        setIsTogglingAutoNetwork(true);
-        try {
-            await modemService.setAutoNetwork(value);
-            setAutoNetworkEnabled(value);
-            showInterstitial(() => { });
-        } catch (error) {
-            ThemedAlertHelper.alert(t('common.error'), t('common.error'));
-            setAutoNetworkEnabled(!value);
-        } finally {
-            setIsTogglingAutoNetwork(false);
-        }
-    };
-
-    const handleNetworkModeChange = async (mode: string) => {
-        if (!modemService) return;
-
-        const changed = mode !== networkMode;
-
-        setShowNetworkModeModal(false); // Close first
-        setIsChangingNetwork(true);
-        try {
-            await modemService.setNetworkMode(mode);
-            setNetworkMode(mode);
-            ThemedAlertHelper.alert(t('common.success'), t('settings.networkModeChanged'));
-            if (changed) {
-                showInterstitial(() => { });
-            }
-        } catch (error: any) {
-            let errorMessage = t('alerts.failedChangeNetwork');
-            if (error?.huaweiErrorCode === '100003') {
-                errorMessage = t('alerts.networkModeNotSupported') || 'Preferred network mode selection is not supported on this modem.';
-            }
-            ThemedAlertHelper.alert(t('common.error'), errorMessage);
-        } finally {
-            setIsChangingNetwork(false);
-        }
-    };
+    const {
+        modemService, loadSettings,
+        mobileDataEnabled, dataRoamingEnabled, autoNetworkEnabled,
+        isTogglingMobileData, isTogglingRoaming, isTogglingAutoNetwork,
+        handleToggleMobileData, handleToggleRoaming, handleToggleAutoNetwork,
+        networkMode, showNetworkModeModal, setShowNetworkModeModal,
+        isChangingNetwork, handleNetworkModeChange,
+        showBandModal, setShowBandModal, selectedBandsDisplay,
+        showMonthlyModal, setShowMonthlyModal, monthlySettings, handleSaveMonthlySettings,
+        showSignalPointingModal, setShowSignalPointingModal,
+    } = useMobileNetwork({ t });
 
     const currentNetworkModeLabel = NETWORK_MODES.find(m => m.value === networkMode)?.labelKey || 'settings.networkAuto';
 
@@ -286,8 +118,6 @@ export default function MobileNetworkSettingsScreen() {
                             isLast
                         />
                     </SettingsSection>
-
-
 
                     {/* Monthly Usage Settings */}
                     <SettingsSection title={t('home.monthlySettings')}>

--- a/src/app/(tabs)/settings/system.tsx
+++ b/src/app/(tabs)/settings/system.tsx
@@ -1,26 +1,17 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import {
     View,
     Text,
     StyleSheet,
     ScrollView,
-    TextInput,
     TouchableOpacity,
-    Modal,
-    ActivityIndicator,
 } from 'react-native';
 import { MaterialIcons } from '@expo/vector-icons';
-import { useRouter } from 'expo-router';
 import { useTheme } from '@/theme';
-import { useAuthStore } from '@/stores/auth.store';
-import { useThemeStore } from '@/stores/theme.store';
-import { ModemService } from '@/services/modem.service';
 import { useTranslation } from '@/i18n';
-import { ThemedAlertHelper, Button, MeshGradientBackground, ThemedSwitch, BouncingDots, AnimatedScreen, AdNative, PageSheetModal } from '@/components';
+import { MeshGradientBackground, ThemedSwitch, BouncingDots, AnimatedScreen, AdNative, PageSheetModal } from '@/components';
 import { SettingsSection, SettingsItem, PageHeader, ProfileEditModal } from '@/components/settings';
-import { showInterstitial } from '@/services/ad.service';
-import { useModemProfileStore } from '@/stores/modem-profile.store';
-import { getModemProfilePassword } from '@/utils/storage';
+import { useSystemSettings } from '@/hooks/settings';
 
 const TIMEZONES = [
     'UTC-12', 'UTC-11', 'UTC-10', 'UTC-9', 'UTC-8', 'UTC-7', 'UTC-6', 'UTC-5',
@@ -29,226 +20,19 @@ const TIMEZONES = [
     'UTC+11', 'UTC+12',
 ];
 
-const formatModemTime = (time: string) => {
-    if (!time) return '...';
-    try {
-        if (time.includes('T')) {
-            const dateObj = new Date(time);
-            if (!isNaN(dateObj.getTime())) {
-                const year = dateObj.getFullYear();
-                const month = String(dateObj.getMonth() + 1).padStart(2, '0');
-                const day = String(dateObj.getDate()).padStart(2, '0');
-                const hours = String(dateObj.getHours()).padStart(2, '0');
-                const minutes = String(dateObj.getMinutes()).padStart(2, '0');
-                const seconds = String(dateObj.getSeconds()).padStart(2, '0');
-                return `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`;
-            }
-            const parts = time.split('T');
-            const datePart = parts[0];
-            const timePart = parts[1]?.split('.')[0].replace('Z', '');
-            return `${datePart} ${timePart}`;
-        }
-
-        let cleaned = time.replace(',', '');
-        const parts = cleaned.split(' ');
-        if (parts.length < 2) return time.replace(/\//g, '-');
-
-        let datePart = parts[0];
-        let timePart = parts[1];
-
-        timePart = timePart.replace(/\./g, ':');
-
-        if (datePart.includes('/')) {
-            const dateSegments = datePart.split('/');
-            if (dateSegments[2].length === 4) {
-                datePart = `${dateSegments[2]}-${dateSegments[1]}-${dateSegments[0]}`;
-            } else {
-                datePart = datePart.replace(/\//g, '-');
-            }
-        }
-
-        return `${datePart} ${timePart}`;
-
-    } catch (e) {
-        return time;
-    }
-};
-
 export default function SystemSettingsScreen() {
-    const router = useRouter();
     const { colors, typography } = useTheme();
     const { t } = useTranslation();
-    const { credentials, login, logout } = useAuthStore();
-    const { themeMode, setThemeMode, language, setLanguage } = useThemeStore();
-    const { profiles, loadProfiles, deleteProfile, updateProfile, switchProfile, isSwitching } = useModemProfileStore();
 
-    // Profile edit state
-    const [showEditProfile, setShowEditProfile] = useState(false);
-    const [editingProfile, setEditingProfile] = useState<{ id: string; name: string; modemIp: string; username: string; password: string } | null>(null);
-
-    useEffect(() => { loadProfiles(); }, []);
-
-    const [modemService, setModemService] = useState<ModemService | null>(null);
-
-    const [currentTime, setCurrentTime] = useState('');
-    const [sntpEnabled, setSntpEnabled] = useState(true);
-    const [ntpServer, setNtpServer] = useState('pool.ntp.org');
-    const [timezone, setTimezone] = useState('UTC+7');
-    const [showTimezoneModal, setShowTimezoneModal] = useState(false);
-    const [isTogglingSntp, setIsTogglingSntp] = useState(false);
-
-    const [modemIp, setModemIp] = useState(credentials?.modemIp || '192.168.8.1');
-    const [modemUsername, setModemUsername] = useState(credentials?.username || 'admin');
-    const [modemPassword, setModemPassword] = useState(credentials?.password || '');
-    const [showPassword, setShowPassword] = useState(false);
-    const [isSavingCredentials, setIsSavingCredentials] = useState(false);
-
-    const hasCredentialsChanges =
-        modemIp !== (credentials?.modemIp || '192.168.8.1') ||
-        modemUsername !== (credentials?.username || 'admin') ||
-        modemPassword !== (credentials?.password || '');
-
-    useEffect(() => {
-        if (credentials?.modemIp) {
-            const service = new ModemService(credentials.modemIp);
-            setModemService(service);
-            loadTime(service);
-
-            const interval = setInterval(() => {
-                service.getCurrentTime().then(setTime => setCurrentTime(setTime)).catch(() => { });
-            }, 1000);
-            return () => clearInterval(interval);
-        }
-    }, [credentials]);
-
-    const loadTime = async (service: ModemService) => {
-        try {
-            const settings = await service.getTimeSettings();
-            setCurrentTime(settings.currentTime);
-            setSntpEnabled(settings.sntpEnabled);
-            setNtpServer(settings.ntpServer);
-            setTimezone(settings.timezone);
-        } catch (e) { }
-    };
-
-    const handleToggleSntp = async (enabled: boolean) => {
-        if (!modemService || isTogglingSntp) return;
-        setIsTogglingSntp(true);
-        try {
-            await modemService.setTimeSettings({ sntpEnabled: enabled });
-            setSntpEnabled(enabled);
-            showInterstitial(() => {});
-        } catch (error) {
-            ThemedAlertHelper.alert(t('common.error'), t('common.error'));
-        } finally {
-            setIsTogglingSntp(false);
-        }
-    };
-
-    const handleTimezoneChange = async (tz: string) => {
-        if (!modemService) return;
-        setShowTimezoneModal(false);
-        try {
-            await modemService.setTimeSettings({ timezone: tz });
-            setTimezone(tz);
-            showInterstitial(() => {});
-        } catch (error) {
-            ThemedAlertHelper.alert(t('common.error'), t('common.error'));
-        }
-    };
-
-    const handleSaveCredentials = async () => {
-        if (isSavingCredentials) return;
-        setIsSavingCredentials(true);
-        try {
-            await login({
-                modemIp,
-                username: modemUsername,
-                password: modemPassword,
-            });
-            showInterstitial(() => {
-                ThemedAlertHelper.alert(t('common.success'), t('settings.credentialsSaved'));
-                router.replace('/settings'); // Force reload of settings context
-            });
-        } catch (error) {
-            ThemedAlertHelper.alert(t('common.error'), t('settings.failedSaveCredentials'));
-        } finally {
-            setIsSavingCredentials(false);
-        }
-    };
-
-    const handleReboot = async () => {
-        ThemedAlertHelper.alert(
-            t('settings.rebootModem'),
-            t('settings.rebootConfirm'),
-            [
-                { text: t('common.cancel'), style: 'cancel' },
-                {
-                    text: t('settings.rebootModem'),
-                    style: 'destructive',
-                    onPress: async () => {
-                        if (modemService) {
-                            try {
-                                await modemService.reboot();
-                                showInterstitial(() => {
-                                    ThemedAlertHelper.alert(t('common.success'), t('settings.rebootSuccess'));
-                                });
-                            } catch (e) {
-                                ThemedAlertHelper.alert(t('common.error'), t('alerts.failedReboot'));
-                            }
-                        }
-                    }
-                }
-            ]
-        );
-    };
-
-    const handleLogout = async () => {
-        ThemedAlertHelper.alert(
-            t('settings.logout'),
-            t('settings.logoutConfirm'),
-            [
-                { text: t('common.cancel'), style: 'cancel' },
-                {
-                    text: t('settings.logout'),
-                    style: 'destructive',
-                    onPress: async () => {
-                        try {
-                            if (modemService) await modemService.logout();
-                        } catch (e) { }
-                        await logout();
-                        router.replace('/login');
-                    }
-                }
-            ]
-        );
-    };
-
-    const handleReset = async () => {
-        ThemedAlertHelper.alert(
-            t('settings.resetFactory'),
-            t('settings.resetConfirm'),
-            [
-                { text: t('common.cancel'), style: 'cancel' },
-                {
-                    text: t('settings.resetFactory'),
-                    style: 'destructive',
-                    onPress: async () => {
-                        if (modemService) {
-                            try {
-                                await modemService.resetFactorySettings();
-                                showInterstitial(() => {
-                                    ThemedAlertHelper.alert(t('common.success'), t('settings.resetSuccess'));
-                                });
-                            } catch (e) {
-                                ThemedAlertHelper.alert(t('common.error'), t('alerts.failedReset'));
-                            }
-                        }
-                    }
-                }
-            ]
-        );
-    };
+    const {
+        formattedTime, sntpEnabled, timezone,
+        showTimezoneModal, setShowTimezoneModal, isTogglingSntp,
+        handleToggleSntp, handleTimezoneChange,
+        profiles, showEditProfile, setShowEditProfile,
+        editingProfile, setEditingProfile, isSwitching, updateProfile,
+        handleOpenEditProfile, handleSwitchProfile, handleDeleteProfile,
+        handleReboot, handleLogout, handleReset,
+    } = useSystemSettings({ t });
 
     return (
         <AnimatedScreen noAnimation>
@@ -262,7 +46,7 @@ export default function SystemSettingsScreen() {
                     <SettingsSection title={t('timeSettings.title')}>
                         <SettingsItem
                             title={t('timeSettings.currentTime')}
-                            value={formatModemTime(currentTime)}
+                            value={formattedTime}
                             showChevron={false}
                         />
                         <SettingsItem
@@ -282,8 +66,6 @@ export default function SystemSettingsScreen() {
                             isLast
                         />
                     </SettingsSection>
-
-
 
                     {/* Modem Profiles */}
                     <SettingsSection title={t('settings.modemControl')}>
@@ -330,34 +112,7 @@ export default function SystemSettingsScreen() {
                                     <View style={styles.profileActions}>
                                         {!profile.isActive && (
                                             <TouchableOpacity
-                                                onPress={() => {
-                                                    ThemedAlertHelper.alert(
-                                                        t('settings.switchProfile'),
-                                                        t('settings.switchProfileConfirm').replace('{{name}}', profile.name),
-                                                        [
-                                                            { text: t('common.cancel'), style: 'cancel' },
-                                                            {
-                                                                text: t('settings.switchProfile'),
-                                                                onPress: async () => {
-                                                                    const success = await switchProfile(profile.id);
-                                                                    if (success) {
-                                                                        ThemedAlertHelper.alert(
-                                                                            t('common.success'),
-                                                                            t('settings.switchSuccess').replace('{{name}}', profile.name)
-                                                                        );
-                                                                    } else {
-                                                                        const err = useModemProfileStore.getState().switchError;
-                                                                        const details = err ? `\n\nError: ${err}` : '';
-                                                                        ThemedAlertHelper.alert(
-                                                                            t('common.error'),
-                                                                            t('settings.switchFailed') + details
-                                                                        );
-                                                                    }
-                                                                }
-                                                            },
-                                                        ]
-                                                    );
-                                                }}
+                                                onPress={() => handleSwitchProfile(profile)}
                                                 disabled={isSwitching}
                                                 style={[styles.profileActionBtn, { borderColor: colors.primary }]}
                                             >
@@ -367,36 +122,13 @@ export default function SystemSettingsScreen() {
                                             </TouchableOpacity>
                                         )}
                                         <TouchableOpacity
-                                            onPress={async () => {
-                                                const pwd = await getModemProfilePassword(profile.id);
-                                                setEditingProfile({
-                                                    id: profile.id,
-                                                    name: profile.name,
-                                                    modemIp: profile.modemIp,
-                                                    username: profile.username,
-                                                    password: pwd,
-                                                });
-                                                setShowEditProfile(true);
-                                            }}
+                                            onPress={() => handleOpenEditProfile(profile)}
                                             style={[styles.profileActionBtn, { borderColor: colors.border }]}
                                         >
                                             <MaterialIcons name="edit" size={16} color={colors.textSecondary} />
                                         </TouchableOpacity>
                                         <TouchableOpacity
-                                            onPress={() => {
-                                                ThemedAlertHelper.alert(
-                                                    t('settings.deleteProfile'),
-                                                    t('settings.deleteProfileConfirm').replace('{{name}}', profile.name),
-                                                    [
-                                                        { text: t('common.cancel'), style: 'cancel' },
-                                                        {
-                                                            text: t('common.delete'),
-                                                            style: 'destructive',
-                                                            onPress: () => deleteProfile(profile.id),
-                                                        },
-                                                    ]
-                                                );
-                                            }}
+                                            onPress={() => handleDeleteProfile(profile)}
                                             style={[styles.profileActionBtn, { borderColor: colors.error }]}
                                         >
                                             <MaterialIcons name="delete-outline" size={16} color={colors.error} />
@@ -474,7 +206,6 @@ const styles = StyleSheet.create({
     innerContent: {
         padding: 16,
     },
-
     modalItem: {
         flexDirection: 'row',
         justifyContent: 'space-between',
@@ -514,4 +245,3 @@ const styles = StyleSheet.create({
         letterSpacing: 0.3,
     },
 });
-

--- a/src/app/(tabs)/settings/update.tsx
+++ b/src/app/(tabs)/settings/update.tsx
@@ -1,300 +1,27 @@
-import React, { useState, useEffect, useCallback, useRef } from 'react';
-import { View, Text, StyleSheet, ActivityIndicator, TouchableOpacity, Linking, Platform, ScrollView } from 'react-native';
-import { Stack, useRouter } from 'expo-router';
-import { MaterialIcons, MaterialCommunityIcons } from '@expo/vector-icons';
-import Animated, {
-    useAnimatedStyle,
-    useSharedValue,
-    withRepeat,
-    withTiming,
-    Easing,
-    cancelAnimation
-} from 'react-native-reanimated';
+import React, { useState } from 'react';
+import { View, Text, StyleSheet, TouchableOpacity, ScrollView } from 'react-native';
+import { Stack } from 'expo-router';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
+import Animated from 'react-native-reanimated';
 import { useTheme } from '@/theme';
 import { useTranslation } from '@/i18n';
 import Constants from 'expo-constants';
-import * as FileSystem from 'expo-file-system/legacy';
-import { MeshGradientBackground, AnimatedScreen, AdNative, ThemedAlertHelper } from '@/components';
+import { MeshGradientBackground, AnimatedScreen, AdNative } from '@/components';
 import { PageHeader, ReleaseNotesModal } from '@/components/settings';
-
-let IntentLauncher: any = null;
-try {
-    IntentLauncher = require('expo-intent-launcher');
-} catch (e) {
-    console.warn('expo-intent-launcher is not available in this environment:', e);
-}
-
-const GITHUB_OWNER = 'alrescha79-cmd';
-const GITHUB_REPO = 'huawei-manager-mobile';
-
-interface ReleaseInfo {
-    tagName: string;
-    version: string;
-    downloadUrl: string;
-    releaseNotes: string;
-    publishedAt: string;
-    isPreRelease: boolean;
-}
-
-/**
- * Compare semantic versions
- * Returns: 1 if v1 > v2, -1 if v1 < v2, 0 if equal
- */
-function compareVersions(v1: string, v2: string): number {
-    const normalize = (v: string) => v.replace(/^v/, '').replace(/-.*$/, '').split('.').map(n => parseInt(n, 10) || 0);
-    const parts1 = normalize(v1);
-    const parts2 = normalize(v2);
-
-    for (let i = 0; i < Math.max(parts1.length, parts2.length); i++) {
-        const p1 = parts1[i] || 0;
-        const p2 = parts2[i] || 0;
-        if (p1 > p2) return 1;
-        if (p1 < p2) return -1;
-    }
-    return 0;
-}
-
+import { useUpdateCheck, useUpdateDownload } from '@/hooks/settings';
 
 export default function UpdateScreen() {
-    const { colors, typography, spacing, isDark } = useTheme();
+    const { colors, typography, isDark } = useTheme();
     const { t } = useTranslation();
-    const router = useRouter();
 
-    const [checking, setChecking] = useState(false);
-    const [updateAvailable, setUpdateAvailable] = useState(false);
-    const [releaseInfo, setReleaseInfo] = useState<ReleaseInfo | null>(null);
-    const [preReleaseInfo, setPreReleaseInfo] = useState<ReleaseInfo | null>(null);
-    const [preReleaseAvailable, setPreReleaseAvailable] = useState(false);
-    const [error, setError] = useState<string | null>(null);
-    const [hasChecked, setHasChecked] = useState(false);
+    const {
+        checking, updateAvailable, releaseInfo, preReleaseInfo, preReleaseAvailable,
+        error, hasChecked, animatedStyle, availableCount, checkUpdate,
+    } = useUpdateCheck();
 
-    const [downloading, setDownloading] = useState(false);
-    const [downloadProgress, setDownloadProgress] = useState(0);
-    const [downloadResumable, setDownloadResumable] = useState<FileSystem.DownloadResumable | null>(null);
-    const isCancelledRef = useRef(false);
+    const { downloading, downloadProgress, handleDownloadAndInstall, handleCancelDownload } = useUpdateDownload({ t });
+
     const [selectedNotes, setSelectedNotes] = useState<{ version: string; notes: string } | null>(null);
-
-    const rotation = useSharedValue(0);
-
-    const animatedStyle = useAnimatedStyle(() => ({
-        transform: [{ rotate: `${rotation.value}deg` }],
-    }));
-
-    useEffect(() => {
-        if (checking) {
-            rotation.value = 0;
-            rotation.value = withRepeat(
-                withTiming(360, { duration: 1000, easing: Easing.linear }),
-                -1,
-                false
-            );
-        } else {
-            cancelAnimation(rotation);
-            rotation.value = 0;
-        }
-    }, [checking]);
-
-    useEffect(() => {
-        checkUpdate();
-    }, []);
-
-    const checkUpdate = useCallback(async () => {
-        setChecking(true);
-        setError(null);
-        setUpdateAvailable(false);
-        setPreReleaseAvailable(false);
-        setReleaseInfo(null);
-        setPreReleaseInfo(null);
-
-        try {
-            const response = await fetch(
-                `https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/releases`,
-                {
-                    headers: {
-                        'Accept': 'application/vnd.github.v3+json',
-                    },
-                }
-            );
-
-            if (!response.ok) {
-                throw new Error(`GitHub API error: ${response.status}`);
-            }
-
-            const releases = await response.json();
-            const currentVersion = Constants.expoConfig?.version || '0.0.0';
-
-            const stableRelease = releases.find((r: any) => !r.prerelease && !r.draft);
-            const preRelease = releases.find((r: any) => r.prerelease && !r.draft);
-
-            const parseRelease = (data: any, isPreRelease: boolean): ReleaseInfo => {
-                const apkAsset = data.assets?.find((asset: any) =>
-                    asset.name?.endsWith('.apk') || asset.name?.includes('universal')
-                );
-
-                let version = '';
-                const tagName = data.tag_name || '';
-
-                const semverMatch = tagName.match(/v?(\d+\.\d+\.\d+)/);
-                if (semverMatch) {
-                    version = semverMatch[1];
-                } else {
-                    const nameMatch = (data.name || '').match(/v?(\d+\.\d+\.\d+)/);
-                    if (nameMatch) {
-                        version = nameMatch[1];
-                    } else if (apkAsset?.name) {
-                        const assetMatch = apkAsset.name.match(/v?(\d+\.\d+\.\d+)/);
-                        if (assetMatch) {
-                            version = assetMatch[1];
-                        }
-                    }
-                }
-
-                return {
-                    tagName: tagName,
-                    version: version,
-                    downloadUrl: apkAsset?.browser_download_url || data.html_url || '',
-                    releaseNotes: data.body || '',
-                    publishedAt: data.published_at || '',
-                    isPreRelease,
-                };
-            };
-
-            if (stableRelease) {
-                const info = parseRelease(stableRelease, false);
-                setReleaseInfo(info);
-                const comparison = compareVersions(info.version, currentVersion);
-                setUpdateAvailable(comparison > 0);
-            }
-
-            if (preRelease) {
-                const info = parseRelease(preRelease, true);
-                setPreReleaseInfo(info);
-                const comparison = info.version ? compareVersions(info.version, currentVersion) : 1;
-                setPreReleaseAvailable(comparison > 0);
-            }
-
-            setHasChecked(true);
-        } catch (err) {
-            console.error('Update check failed:', err);
-            setError(err instanceof Error ? err.message : 'Unknown error');
-            setHasChecked(true);
-        } finally {
-            setChecking(false);
-        }
-    }, []);
-
-    const handleDownloadAndInstall = async (url: string, versionName: string) => {
-        if (Platform.OS !== 'android') {
-            Linking.openURL(url);
-            return;
-        }
-
-        try {
-            setDownloading(true);
-            setDownloadProgress(0);
-            isCancelledRef.current = false;
-
-            const filename = `huawei-manager-v${versionName}.apk`;
-            const localUri = `${FileSystem.cacheDirectory}${filename}`;
-
-            const fileInfo = await FileSystem.getInfoAsync(localUri);
-            if (fileInfo.exists) {
-                await FileSystem.deleteAsync(localUri, { idempotent: true });
-            }
-
-            const resumable = FileSystem.createDownloadResumable(
-                url,
-                localUri,
-                {},
-                (downloadProgressData) => {
-                    const progress = downloadProgressData.totalBytesWritten / downloadProgressData.totalBytesExpectedToWrite;
-                    setDownloadProgress(Math.round(progress * 100));
-                }
-            );
-
-            setDownloadResumable(resumable);
-
-            const result = await resumable.downloadAsync();
-            setDownloading(false);
-            setDownloadResumable(null);
-
-            if (result && result.uri) {
-                let launched = false;
-                if (Platform.OS === 'android') {
-                    try {
-                        const contentUri = await FileSystem.getContentUriAsync(result.uri);
-                        if (IntentLauncher && IntentLauncher.startActivityAsync) {
-                            await IntentLauncher.startActivityAsync('android.intent.action.VIEW', {
-                                data: contentUri,
-                                type: 'application/vnd.android.package-archive',
-                                flags: 1, // FLAG_GRANT_READ_URI_PERMISSION
-                            });
-                            launched = true;
-                        }
-                    } catch (e) {
-                        console.warn('Failed to launch APK installation intent:', e);
-                    }
-                }
-
-                if (!launched) {
-                    ThemedAlertHelper.alert(
-                        t('common.success') || 'Success',
-                        t('settings.downloadComplete') || 'Update downloaded successfully. Please open and install the APK file manually, or open the link in your browser.',
-                        [
-                            { text: t('common.ok') || 'OK' },
-                            { text: t('settings.downloadUpdate') || 'Open Browser', onPress: () => Linking.openURL(url) }
-                        ]
-                    );
-                }
-            } else {
-                throw new Error('Download failed: result is empty');
-            }
-        } catch (err: any) {
-            if (isCancelledRef.current) {
-                isCancelledRef.current = false;
-                return;
-            }
-            console.error('Download/Install failed:', err);
-            setDownloading(false);
-            setDownloadResumable(null);
-
-            const message = err instanceof Error ? err.message : String(err);
-            ThemedAlertHelper.alert(
-                t('common.error') || 'Error',
-                `${t('settings.downloadFailed') || 'Failed to download or install update. Please try again or download manually.'}\n\n${message}`,
-                [
-                    { text: t('common.ok') || 'OK' },
-                    { text: t('settings.downloadUpdate') || 'Open Browser', onPress: () => Linking.openURL(url) }
-                ]
-            );
-        }
-    };
-
-    const handleCancelDownload = async () => {
-        if (downloadResumable) {
-            try {
-                isCancelledRef.current = true;
-                await downloadResumable.cancelAsync();
-                setDownloading(false);
-                setDownloadProgress(0);
-                setDownloadResumable(null);
-                ThemedAlertHelper.alert(
-                    t('settings.downloadCancelledTitle') || 'Cancelled',
-                    t('settings.downloadCancelledMessage') || 'Download cancelled.'
-                );
-            } catch (e) {
-                console.error('Error cancelling download:', e);
-                isCancelledRef.current = false;
-                const message = e instanceof Error ? e.message : String(e);
-                ThemedAlertHelper.alert(
-                    t('common.error') || 'Error',
-                    `${t('settings.downloadFailed') || 'Failed to download or install update. Please try again or download manually.'}\n\n${message}`
-                );
-            }
-        }
-    };
-
-    const availableCount = (updateAvailable ? 1 : 0) + (preReleaseAvailable ? 1 : 0);
 
     return (
         <AnimatedScreen noAnimation>
@@ -442,7 +169,7 @@ export default function UpdateScreen() {
 
                                                 <View style={styles.releaseActions}>
                                                     <TouchableOpacity
-                                                        style={[styles.downloadBtn, { backgroundColor: '#10B981' }]} // Teal/green
+                                                        style={[styles.downloadBtn, { backgroundColor: '#10B981' }]}
                                                         onPress={() => releaseInfo.downloadUrl && handleDownloadAndInstall(releaseInfo.downloadUrl, releaseInfo.version)}
                                                     >
                                                         <MaterialCommunityIcons name="download" size={18} color="#FFF" />
@@ -489,7 +216,7 @@ export default function UpdateScreen() {
 
                                                 <View style={styles.releaseActions}>
                                                     <TouchableOpacity
-                                                        style={[styles.downloadBtn, { backgroundColor: '#F59E0B' }]} // Yellow/Orange
+                                                        style={[styles.downloadBtn, { backgroundColor: '#F59E0B' }]}
                                                         onPress={() => preReleaseInfo.downloadUrl && handleDownloadAndInstall(preReleaseInfo.downloadUrl, preReleaseInfo.version || preReleaseInfo.tagName)}
                                                     >
                                                         <MaterialCommunityIcons name="lightning-bolt" size={18} color="#FFF" />

--- a/src/app/(tabs)/sms.tsx
+++ b/src/app/(tabs)/sms.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import {
   View,
   Text,
@@ -9,432 +9,45 @@ import {
   StatusBar,
   Platform,
   TextInput,
-  Linking,
-  AppState,
 } from 'react-native';
 import { MaterialIcons } from '@expo/vector-icons';
-import { LinearGradient } from 'expo-linear-gradient';
-import dayjs from 'dayjs';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTheme } from '@/theme';
-import { Card, CardHeader, Input, Button, ThemedAlertHelper, MeshGradientBackground, AnimatedScreen, BouncingDots, RefreshIndicator, AdBanner, AdNative } from '@/components';
-import { SMSListItem, SMSStatsCard, SMSDetailModal, SMSStatsSkeleton, SMSListSkeleton, SMSSearchSkeleton, smsStyles as styles, SMSFilterType, KeyboardAnimatedView } from '@/components/sms';
+import { MeshGradientBackground, AnimatedScreen, BouncingDots, RefreshIndicator, AdNative } from '@/components';
+import { SMSListItem, SMSStatsCard, SMSDetailModal, SMSStatsSkeleton, SMSListSkeleton, SMSSearchSkeleton, smsStyles as styles, KeyboardAnimatedView } from '@/components/sms';
 import { formatTimeAgo } from '@/utils/formatters';
-import { useAuthStore } from '@/stores/auth.store';
-import { useSMSStore } from '@/stores/sms.store';
-import { SMSService } from '@/services/sms.service';
-import { checkNewSMSNotification } from '@/services/notification.service';
 import { useTranslation } from '@/i18n';
-import { SMSMessage } from '@/types';
+import { useSMSData, useSMSActions, useMessageLinks } from '@/hooks/sms';
 
 export default function SMSScreen() {
   const { colors, typography, spacing, glassmorphism, isDark } = useTheme();
   const { t } = useTranslation();
-  const { credentials } = useAuthStore();
   const insets = useSafeAreaInsets();
   const bottomOffset = 88 + (insets.bottom > 0 ? insets.bottom : 16);
-  const {
-    messages,
-    smsCount,
-    setMessages,
-    setSMSCount,
-    removeMessage,
-  } = useSMSStore();
 
-  const [isRefreshing, setIsRefreshing] = useState(false);
-  const [pullProgress, setPullProgress] = useState(0);
-  const [smsService, setSMSService] = useState<SMSService | null>(null);
-  const [showCompose, setShowCompose] = useState(false);
-  const [newPhone, setNewPhone] = useState('');
-  const [newMessage, setNewMessage] = useState('');
-  const [isSending, setIsSending] = useState(false);
-  const [smsSupported, setSmsSupported] = useState(true);
-
-  const [selectedMessage, setSelectedMessage] = useState<SMSMessage | null>(null);
-  const [showDetail, setShowDetail] = useState(false);
-  const [replyMessage, setReplyMessage] = useState('');
-  const [searchQuery, setSearchQuery] = useState('');
-  const [messageFilter, setMessageFilter] = useState<SMSFilterType>('all');
-
-  const [isSelectionMode, setIsSelectionMode] = useState(false);
-  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
-
-
-  useEffect(() => {
-    if (credentials?.modemIp) {
-      const service = new SMSService(credentials.modemIp);
-      setSMSService(service);
-
-      service.resetSMSCache();
-
-      loadData(service);
-
-      const intervalId = setInterval(() => {
-        if (AppState.currentState === 'active') {
-          loadDataSilent(service);
-        }
-      }, 10000);
-
-      return () => clearInterval(intervalId);
-    }
-  }, [credentials]);
-
-  const loadData = async (service: SMSService) => {
-    try {
-      setIsRefreshing(true);
-
-      let isSupported = false;
-      try {
-        isSupported = await service.isSMSSupported();
-      } catch (error: any) {
-        if (error?.message?.includes('125003') || error?.message?.includes('125002')) {
-          const { requestRelogin } = useAuthStore.getState();
-          requestRelogin();
-        }
-        setSmsSupported(false);
-        return;
-      }
-
-      if (!isSupported) {
-        setSmsSupported(false);
-        setMessages([]);
-        setSMSCount({
-          localUnread: 0,
-          localInbox: 0,
-          localOutbox: 0,
-          localDraft: 0,
-          simUnread: 0,
-          simInbox: 0,
-          simOutbox: 0,
-          simDraft: 0,
-          newMsg: 0,
-          localDeleted: 0,
-          simDeleted: 0,
-          localMax: 0,
-          simMax: 0,
-        });
-        return;
-      }
-
-      try {
-        const [inboxMessages, count] = await Promise.all([
-          service.getSMSList(1, 20, 1),
-          service.getSMSCount(),
-        ]);
-
-        let sentMessages: typeof inboxMessages = [];
-        try {
-          if (count.localOutbox > 0) {
-            sentMessages = await service.getSMSList(1, 20, 2);
-          }
-        } catch (outboxError) {
-          console.log('Outbox loading skipped:', outboxError);
-        }
-
-        const allMessages = [...inboxMessages, ...sentMessages].sort(
-          (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
-        );
-
-        setMessages(allMessages);
-        setSMSCount(count);
-        setSmsSupported(true);
-
-        if (count.localUnread > 0) {
-          checkNewSMSNotification(count.localUnread, {
-            title: t('notifications.newSms'),
-            body: (n) => t('notifications.newSmsBody', { count: n }),
-          });
-        }
-      } catch (error: any) {
-        if (error?.message?.includes('125003') || error?.message?.includes('125002')) {
-          const { requestRelogin } = useAuthStore.getState();
-          requestRelogin();
-        } else {
-          setSmsSupported(false);
-        }
-      }
-    } finally {
-      setIsRefreshing(false);
-    }
-  };
-
-  const loadDataSilent = async (service: SMSService) => {
-    try {
-      const isSupported = await service.isSMSSupported();
-      if (!isSupported) {
-        setSmsSupported(false);
-        return;
-      }
-
-      try {
-        const [inboxMessages, count] = await Promise.all([
-          service.getSMSList(1, 20, 1),
-          service.getSMSCount(),
-        ]);
-
-        let sentMessages: typeof inboxMessages = [];
-        try {
-          if (count.localOutbox > 0) {
-            sentMessages = await service.getSMSList(1, 20, 2);
-          }
-        } catch {
-        }
-
-        const allMessages = [...inboxMessages, ...sentMessages].sort(
-          (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
-        );
-
-        setMessages(allMessages);
-        setSMSCount(count);
-      } catch (error: any) {
-        if (error?.message?.includes('125003') || error?.message?.includes('125002')) {
-          const { requestRelogin } = useAuthStore.getState();
-          requestRelogin();
-        }
-      }
-    } catch (error: any) {
-      if (error?.message?.includes('125003') || error?.message?.includes('125002')) {
-        const { requestRelogin } = useAuthStore.getState();
-        requestRelogin();
-      }
-    }
-  };
-
-  const handleRefresh = () => {
-    if (smsService) {
-      loadData(smsService);
-    }
-  };
-
-  const handleDelete = async (index: string) => {
-    if (!smsService) return;
-
-    ThemedAlertHelper.alert(
-      t('sms.deleteSms'),
-      t('sms.deleteConfirm'),
-      [
-        { text: t('common.cancel'), style: 'cancel' },
-        {
-          text: t('common.delete'),
-          style: 'destructive',
-          onPress: async () => {
-            try {
-              await smsService.deleteSMS(index);
-              removeMessage(index);
-              ThemedAlertHelper.alert(t('common.success'), t('sms.messageDeleted'));
-            } catch (error) {
-              ThemedAlertHelper.alert(t('common.error'), t('alerts.failedDeleteSms'));
-            }
-          },
-        },
-      ]
-    );
-  };
-
-  const handleLongPress = (message: SMSMessage) => {
-    if (!isSelectionMode) {
-      setIsSelectionMode(true);
-      setSelectedIds(new Set([`${message.boxType}-${message.index}`]));
-    }
-  };
-
-  const toggleSelect = (message: SMSMessage) => {
-    const id = `${message.boxType}-${message.index}`;
-    setSelectedIds(prev => {
-      const newSet = new Set(prev);
-      if (newSet.has(id)) {
-        newSet.delete(id);
-      } else {
-        newSet.add(id);
-      }
-      return newSet;
-    });
-  };
-
-  const handleSelectAll = () => {
-    if (selectedIds.size === filteredMessages.length) {
-      setSelectedIds(new Set());
-    } else {
-      const allIds = filteredMessages.map(m => `${m.boxType}-${m.index}`);
-      setSelectedIds(new Set(allIds));
-    }
-  };
-
-  const exitSelectionMode = () => {
-    setIsSelectionMode(false);
-    setSelectedIds(new Set());
-  };
-
-  const handleDeleteSelected = async () => {
-    if (!smsService || selectedIds.size === 0) return;
-
-    ThemedAlertHelper.alert(
-      t('sms.deleteSelected'),
-      t('sms.deleteSelectedConfirm', { count: selectedIds.size }),
-      [
-        { text: t('common.cancel'), style: 'cancel' },
-        {
-          text: t('common.delete'),
-          style: 'destructive',
-          onPress: async () => {
-            try {
-              const idsToDelete = Array.from(selectedIds);
-              for (const id of idsToDelete) {
-                const index = id.split('-').slice(1).join('-');
-                await smsService.deleteSMS(index);
-                removeMessage(index);
-              }
-              ThemedAlertHelper.alert(
-                t('common.success'),
-                t('sms.messagesDeleted', { count: idsToDelete.length })
-              );
-              exitSelectionMode();
-            } catch (error) {
-              ThemedAlertHelper.alert(t('common.error'), t('alerts.failedDeleteSms'));
-            }
-          },
-        },
-      ]
-    );
-  };
-
-  const handleSend = async () => {
-    if (!smsService || !newPhone || !newMessage) {
-      ThemedAlertHelper.alert(t('common.error'), t('sms.fillAllFields'));
-      return;
-    }
-
-    setIsSending(true);
-    try {
-      await smsService.sendSMS(newPhone, newMessage);
-      ThemedAlertHelper.alert(t('common.success'), t('sms.messageSent'));
-      setShowCompose(false);
-      setNewPhone('');
-      setNewMessage('');
-      handleRefresh();
-    } catch (error) {
-      ThemedAlertHelper.alert(t('common.error'), t('alerts.failedSendSms'));
-    } finally {
-      setIsSending(false);
-    }
-  };
-
-  const handleOpenDetail = async (message: SMSMessage) => {
-    setSelectedMessage(message);
-    setReplyMessage('');
-    setShowDetail(true);
-
-    if (smsService && message.smstat === '0') {
-      try {
-        await smsService.markAsRead(message.index);
-      } catch (error) {
-        console.error('Failed to mark SMS as read:', error);
-      }
-    }
-  };
-
-  const handleReply = async () => {
-    if (!smsService || !selectedMessage || !replyMessage) {
-      ThemedAlertHelper.alert(t('common.error'), t('sms.fillAllFields'));
-      return;
-    }
-
-    setIsSending(true);
-    try {
-      await smsService.sendSMS(selectedMessage.phone, replyMessage);
-      ThemedAlertHelper.alert(t('common.success'), t('sms.messageSent'));
-      setReplyMessage('');
-      setShowDetail(false);
-      setSelectedMessage(null);
-      handleRefresh();
-    } catch (error) {
-      ThemedAlertHelper.alert(t('common.error'), t('alerts.failedSendSms'));
-    } finally {
-      setIsSending(false);
-    }
-  };
-
-  const filteredMessages = messages.filter(msg => {
-    if (messageFilter === 'unread' && msg.smstat !== '0') return false;
-    if (messageFilter === 'sent' && msg.boxType !== 2) return false;
-
-    if (!searchQuery.trim()) return true;
-    const query = searchQuery.toLowerCase();
-    return (
-      msg.phone.toLowerCase().includes(query) ||
-      msg.content.toLowerCase().includes(query)
-    );
+  const smsData = useSMSData({ t });
+  const smsActions = useSMSActions({
+    smsService: smsData.smsService,
+    messages: smsData.messages,
+    filteredMessages: smsData.filteredMessages,
+    removeMessage: smsData.removeMessage,
+    handleRefresh: smsData.handleRefresh,
+    t,
   });
+  const { renderMessageWithLinks } = useMessageLinks();
 
+  const {
+    isRefreshing, smsSupported, searchQuery, setSearchQuery,
+    messageFilter, setMessageFilter, smsCount, filteredMessages, handleRefresh,
+  } = smsData;
 
-  const handleMarkAllAsRead = async () => {
-    if (!smsService) return;
-    const unreadMessages = messages.filter(m => m.smstat === '0');
-    for (const msg of unreadMessages) {
-      try {
-        await smsService.markAsRead(msg.index);
-      } catch (error) {
-        console.error('Failed to mark SMS as read:', error);
-      }
-    }
-    handleRefresh();
-  };
-
-  const renderMessageWithLinks = (content: string) => {
-    const urlRegex = /(https?:\/\/[^\s]+)|(www\.[^\s]+)|([a-zA-Z0-9][-a-zA-Z0-9]*\.[a-zA-Z]{2,}(?:\/[^\s]*)?)/gi;
-
-    const parts = content.split(urlRegex).filter(Boolean);
-
-    if (parts.length === 1 && !urlRegex.test(content)) {
-      return (
-        <Text style={[typography.body, { color: colors.text, lineHeight: 22 }]}>
-          {content}
-        </Text>
-      );
-    }
-
-    urlRegex.lastIndex = 0;
-
-    const elements: React.ReactNode[] = [];
-    let lastIndex = 0;
-    let match;
-    let key = 0;
-
-    while ((match = urlRegex.exec(content)) !== null) {
-      if (match.index > lastIndex) {
-        elements.push(
-          <Text key={key++} style={[typography.body, { color: colors.text, lineHeight: 22 }]}>
-            {content.substring(lastIndex, match.index)}
-          </Text>
-        );
-      }
-
-      const url = match[0];
-      const fullUrl = url.startsWith('http') ? url : `https://${url}`;
-
-      elements.push(
-        <Text
-          key={key++}
-          style={[typography.body, { color: colors.primary, lineHeight: 22, textDecorationLine: 'underline' }]}
-          onPress={() => Linking.openURL(fullUrl)}
-        >
-          {url}
-        </Text>
-      );
-
-      lastIndex = match.index + match[0].length;
-    }
-
-    if (lastIndex < content.length) {
-      elements.push(
-        <Text key={key++} style={[typography.body, { color: colors.text, lineHeight: 22 }]}>
-          {content.substring(lastIndex)}
-        </Text>
-      );
-    }
-
-    return <Text>{elements}</Text>;
-  };
+  const {
+    showCompose, setShowCompose, newPhone, setNewPhone, newMessage, setNewMessage,
+    isSending, handleSend, selectedMessage, setSelectedMessage, showDetail, setShowDetail,
+    replyMessage, setReplyMessage, handleOpenDetail, handleReply,
+    isSelectionMode, selectedIds, handleLongPress, toggleSelect, handleSelectAll,
+    exitSelectionMode, handleDeleteSelected, handleDelete, handleMarkAllAsRead,
+  } = smsActions;
 
   return (
     <>
@@ -544,7 +157,6 @@ export default function SMSScreen() {
 
             {!smsSupported || filteredMessages.length === 0 ? (
               <>
-
                 <View style={[styles.emptyState, {
                   backgroundColor: isDark ? glassmorphism.background.dark.card : glassmorphism.background.light.card,
                   borderWidth: 1,
@@ -556,7 +168,6 @@ export default function SMSScreen() {
                     {isRefreshing ? t('sms.loadingMessages') : searchQuery ? t('sms.noSearchResults') : `${t('sms.noMessages')}\n${t('sms.smsNotSupported')}`}
                   </Text>
                 </View>
-
               </>
             ) : (
               <View style={{ marginBottom: spacing.md }}>
@@ -640,9 +251,7 @@ export default function SMSScreen() {
               onPress={() => setShowCompose(true)}
               activeOpacity={0.8}
             >
-
               <MaterialIcons name="add" size={28} color={colors.text} />
-
             </TouchableOpacity>
           )}
         </MeshGradientBackground>

--- a/src/app/login.tsx
+++ b/src/app/login.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import {
   View,
   Text,
@@ -7,271 +7,28 @@ import {
   Platform,
   ScrollView,
   TouchableOpacity,
-  Linking,
-  FlatList,
 } from 'react-native';
-import { useRouter } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import Constants from 'expo-constants';
-import * as Device from 'expo-device';
-import * as MailComposer from 'expo-mail-composer';
 import { MaterialIcons } from '@expo/vector-icons';
 import { useTheme } from '@/theme';
-import { Card, Input, Button, WebViewLogin, ThemedAlertHelper, PageSheetModal } from '@/components';
-import { useAuthStore } from '@/stores/auth.store';
-import { useModemProfileStore } from '@/stores/modem-profile.store';
-import { getModemProfilePassword } from '@/utils/storage';
-import { networkService } from '@/services/network.service';
-import { ModemAPIClient } from '@/services/api.service';
+import { Card, Input, Button, WebViewLogin, PageSheetModal } from '@/components';
 import { useTranslation } from '@/i18n';
-import { ModemProfile } from '@/types';
+import { useLogin } from '@/hooks/useLogin';
 
 export default function LoginScreen() {
-  const router = useRouter();
   const { colors, typography, spacing, borderRadius } = useTheme();
-  const { login, isLoading, error, setError, credentials, loadCredentials } = useAuthStore();
-  const { profiles, loadProfiles, addProfile, ensureProfile } = useModemProfileStore();
   const { t } = useTranslation();
 
-  const [modemIp, setModemIp] = useState('192.168.8.1');
-  const [username, setUsername] = useState('admin');
-  const [password, setPassword] = useState('');
-  const [isDetecting, setIsDetecting] = useState(false);
-  const [showWebViewLogin, setShowWebViewLogin] = useState(false);
-  const [isDirectLogging, setIsDirectLogging] = useState(false);
-  const [showWebViewOption, setShowWebViewOption] = useState(false);
-  const [isAutoLoginReady, setIsAutoLoginReady] = useState(false);
-  const [selectedProfileId, setSelectedProfileId] = useState<string | null>(null);
-  const [showAddProfile, setShowAddProfile] = useState(false);
-  const [newProfileName, setNewProfileName] = useState('');
-  const [isSavingProfile, setIsSavingProfile] = useState(false);
-
-  useEffect(() => {
-    const initCredentials = async () => {
-      await loadCredentials();
-      await loadProfiles();
-      setIsAutoLoginReady(true);
-    };
-    initCredentials();
-  }, []);
-
-  useEffect(() => {
-    if (isAutoLoginReady && credentials) {
-      // Pre-select active profile if any
-      const active = profiles.find((p) => p.isActive);
-      if (active) {
-        setSelectedProfileId(active.id);
-      }
-      setModemIp(credentials.modemIp || '192.168.8.1');
-      setUsername(credentials.username || 'admin');
-      setPassword(credentials.password || '');
-    }
-  }, [isAutoLoginReady, credentials]);
-
-  const selectProfile = async (profile: ModemProfile) => {
-    setSelectedProfileId(profile.id);
-    setModemIp(profile.modemIp);
-    setUsername(profile.username);
-    const pwd = await getModemProfilePassword(profile.id);
-    setPassword(pwd);
-    setError(null);
-    setShowWebViewOption(false);
-  };
-
-  const handleSaveProfile = async () => {
-    if (!newProfileName.trim()) {
-      ThemedAlertHelper.alert(t('common.error'), t('settings.profileName') + ' ' + t('common.error').toLowerCase());
-      return;
-    }
-    if (profiles.length >= 5) {
-      ThemedAlertHelper.alert(t('common.error'), t('settings.profileLimitReached'));
-      return;
-    }
-    setIsSavingProfile(true);
-    const result = await addProfile({
-      name: newProfileName.trim(),
-      modemIp,
-      username,
-      password,
-    });
-    setIsSavingProfile(false);
-    if (result) {
-      setNewProfileName('');
-      setShowAddProfile(false);
-      setSelectedProfileId(result.id);
-    }
-  };
-
-  const detectModemIP = async () => {
-    setIsDetecting(true);
-    try {
-      const isWiFi = await networkService.isConnectedToWiFi();
-
-      if (!isWiFi) {
-        ThemedAlertHelper.alert(
-          t('login.wifiRequired'),
-          t('login.wifiRequiredMessage')
-        );
-        setIsDetecting(false);
-        return;
-      }
-
-      const detectedIP = await networkService.detectGatewayIP();
-      setModemIp(detectedIP);
-    } catch (err) {
-      console.error('Error detecting modem IP:', err);
-    } finally {
-      setIsDetecting(false);
-    }
-  };
-
-  const handleLoginPress = async () => {
-    setError(null);
-    setShowWebViewOption(false);
-
-    if (!modemIp) {
-      ThemedAlertHelper.alert(t('common.error'), t('login.enterModemIp'));
-      return;
-    }
-
-    setIsDirectLogging(true);
-
-    const apiClient = new ModemAPIClient(modemIp);
-    let success = false;
-    let lastError = null;
-
-    for (let attempt = 1; attempt <= 3; attempt++) {
-      try {
-        console.log(`[Login Page] Attempt ${attempt}/3...`);
-        success = await apiClient.login(username, password);
-
-        if (success) {
-          console.log('[Login Page] Direct login successful!');
-          await login({
-            modemIp,
-            username,
-            password,
-          });
-          // Auto-save profile with default name if this modem IP is not yet saved
-          await ensureProfile({ modemIp, username, password });
-          setIsDirectLogging(false);
-          router.replace('/(tabs)/home');
-          return;
-        }
-      } catch (err: any) {
-        lastError = err;
-        console.log(`[Login Page] Attempt ${attempt} failed:`, err.message);
-        if (attempt < 3) {
-          await new Promise(resolve => setTimeout(resolve, 500));
-        }
-      }
-    }
-
-    setIsDirectLogging(false);
-
-    setShowWebViewOption(true);
-    ThemedAlertHelper.alert(
-      t('login.directLoginFailed'),
-      t('login.directLoginFailedMessage'),
-      [
-        { text: t('common.cancel'), style: 'cancel' },
-        { text: t('login.openWebLogin'), onPress: () => setShowWebViewLogin(true) }
-      ]
-    );
-  };
-
-  const handleWebViewLoginSuccess = async () => {
-    setShowWebViewLogin(false);
-
-    try {
-      await login({
-        modemIp,
-        username,
-        password,
-      });
-      // Auto-save profile with default name if this modem IP is not yet saved
-      await ensureProfile({ modemIp, username, password });
-
-      ThemedAlertHelper.alert(t('common.success'), t('login.loginSuccess'), [
-        {
-          text: t('common.ok'),
-          onPress: () => router.replace('/(tabs)/home'),
-        },
-      ]);
-    } catch (err) {
-      console.error('[Login] Error saving credentials:', err);
-      const errorMessage = err instanceof Error ? err.message : t('login.loginFailed');
-      ThemedAlertHelper.alert(t('common.error'), errorMessage);
-      setError(errorMessage);
-    }
-  };
-
-  const handleReportIssue = async () => {
-    const deviceString = `${Device.manufacturer || ''} ${Device.modelName || 'Unknown Device'}`.trim();
-    const osString = `${Device.osName || 'Unknown OS'} ${Device.osVersion || ''}`;
-    const appVersion = Constants.expoConfig?.version || '1.0.0';
-    const dateString = new Date().toLocaleDateString();
-
-    const reportTemplate = `=== BUG REPORT / FEATURE REQUEST ===
-
-📱 Device: ${deviceString}
-📲 OS: ${osString}
-📦 App Version: ${appVersion}
-🔧 Modem IP: ${modemIp || 'Not set'}
-📅 Date: ${dateString}
-
----
-
-📝 Description (please fill in):
-[Describe the issue you're experiencing. Include any error messages you see.]
-
-🔄 Steps to Reproduce:
-1. Open App
-2. Enter credentials
-3. [What happens next?]
-
----
-`;
-
-    const emailSubject = `[Huawei Manager] Login Issue - ${deviceString}`;
-    const githubTitle = encodeURIComponent(`Login Issue - ${deviceString}`);
-    const githubBody = encodeURIComponent(reportTemplate);
-    const githubUrl = `https://github.com/alrescha79-cmd/huawei-manager-mobile/issues/new?title=${githubTitle}&body=${githubBody}`;
-
-    ThemedAlertHelper.alert(
-      t('login.reportIssue'),
-      t('login.reportIssueMessage'),
-      [
-        { text: t('common.cancel'), style: 'cancel' },
-        {
-          text: 'GitHub Issue',
-          onPress: () => {
-            Linking.openURL(githubUrl).catch(() => {
-              ThemedAlertHelper.alert(t('common.error'), 'Could not open GitHub');
-            });
-          }
-        },
-        {
-          text: 'Email',
-          onPress: async () => {
-            const isAvailable = await MailComposer.isAvailableAsync();
-            if (isAvailable) {
-              await MailComposer.composeAsync({
-                recipients: ['anggun@cakson.my.id'],
-                subject: emailSubject,
-                body: reportTemplate,
-              });
-            } else {
-              const mailtoUrl = `mailto:anggun@cakson.my.id?subject=${encodeURIComponent(emailSubject)}&body=${encodeURIComponent(reportTemplate)}`;
-              Linking.openURL(mailtoUrl).catch(() => {
-                ThemedAlertHelper.alert(t('common.error'), 'Could not open email client');
-              });
-            }
-          }
-        }
-      ]
-    );
-  };
+  const {
+    modemIp, setModemIp, username, setUsername, password, setPassword,
+    error, isLoading, isDetecting, isDirectLogging,
+    showWebViewLogin, setShowWebViewLogin, showWebViewOption,
+    profiles, selectedProfileId, showAddProfile, setShowAddProfile,
+    newProfileName, setNewProfileName, isSavingProfile,
+    selectProfile, handleSaveProfile, detectModemIP,
+    handleLoginPress, handleWebViewLoginSuccess, handleReportIssue,
+  } = useLogin({ t });
 
   return (
     <KeyboardAvoidingView
@@ -461,7 +218,6 @@ export default function LoginScreen() {
         onLoginSuccess={handleWebViewLoginSuccess}
         onTimeout={() => {
           setShowWebViewLogin(false);
-          setShowWebViewOption(true);
         }}
       />
 

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -8,3 +8,18 @@ export * from './wifi/useWiFiSettings';
 export * from './wifi/useWiFiDevices';
 export * from './wifi/useGuestWiFi';
 export * from './wifi/useParentalControls';
+
+// SMS hooks
+export * from './sms/useSMSData';
+export * from './sms/useSMSActions';
+export * from './sms/useMessageLinks';
+
+// Settings hooks
+export * from './settings/useUpdateCheck';
+export * from './settings/useUpdateDownload';
+export * from './settings/useSystemSettings';
+export * from './settings/useLanSettings';
+export * from './settings/useMobileNetwork';
+
+// Auth hooks
+export * from './useLogin';

--- a/src/hooks/settings/index.ts
+++ b/src/hooks/settings/index.ts
@@ -1,0 +1,5 @@
+export * from './useUpdateCheck';
+export * from './useUpdateDownload';
+export * from './useSystemSettings';
+export * from './useLanSettings';
+export * from './useMobileNetwork';

--- a/src/hooks/settings/useLanSettings.ts
+++ b/src/hooks/settings/useLanSettings.ts
@@ -1,0 +1,259 @@
+import { useState, useEffect } from 'react';
+import { useAuthStore } from '@/stores/auth.store';
+import { NetworkSettingsService } from '@/services/network.settings.service';
+import { ThemedAlertHelper } from '@/components';
+import { showInterstitial } from '@/services/ad.service';
+
+type EthernetMode = 'auto' | 'lan_only' | 'pppoe' | 'dynamic_ip' | 'pppoe_dynamic';
+
+interface UseLanSettingsProps {
+    t: (key: string, options?: any) => string;
+}
+
+export function useLanSettings({ t }: UseLanSettingsProps) {
+    const { credentials } = useAuthStore();
+    const [networkSettingsService, setNetworkSettingsService] = useState<NetworkSettingsService | null>(null);
+
+    // Ethernet
+    const [ethernetMode, setEthernetMode] = useState<EthernetMode>('auto');
+    const [ethernetStatus, setEthernetStatus] = useState<any>({ connected: false });
+    const [isChangingEthernet, setIsChangingEthernet] = useState(false);
+    const [showEthernetModal, setShowEthernetModal] = useState(false);
+
+    // DHCP
+    const [dhcpSettings, setDhcpSettings] = useState({
+        dhcpIPAddress: '192.168.8.1',
+        dhcpLanNetmask: '255.255.255.0',
+        dhcpStatus: true,
+        dhcpStartIPAddress: '192.168.8.100',
+        dhcpEndIPAddress: '192.168.8.200',
+        dhcpLeaseTime: 86400,
+        dnsStatus: true,
+    });
+    const [isTogglingDhcp, setIsTogglingDhcp] = useState(false);
+    const [isSavingDhcp, setIsSavingDhcp] = useState(false);
+    const [showLeaseTimeDropdown, setShowLeaseTimeDropdown] = useState(false);
+
+    // APN
+    const [apnProfiles, setApnProfiles] = useState<any[]>([]);
+    const [activeApnProfileId, setActiveApnProfileId] = useState('');
+    const [showApnModal, setShowApnModal] = useState(false);
+    const [editingApn, setEditingApn] = useState<any | null>(null);
+    const [isSavingApn, setIsSavingApn] = useState(false);
+
+    useEffect(() => {
+        if (credentials?.modemIp) {
+            const service = new NetworkSettingsService(credentials.modemIp);
+            setNetworkSettingsService(service);
+            loadEthernet(service);
+            loadDhcp(service);
+            loadApn(service);
+        }
+    }, [credentials]);
+
+    const loadEthernet = async (service: NetworkSettingsService) => {
+        try {
+            const settings = await service.getEthernetSettings();
+            setEthernetMode(settings.connectionMode);
+            setEthernetStatus(settings.status);
+        } catch (e) { }
+    };
+
+    const loadDhcp = async (service: NetworkSettingsService) => {
+        try {
+            const settings = await service.getDHCPSettings();
+            setDhcpSettings(settings);
+        } catch (e) { }
+    };
+
+    const loadApn = async (service: NetworkSettingsService) => {
+        try {
+            const profiles = await service.getAPNProfiles();
+            const activeId = await service.getActiveAPNProfile();
+            setActiveApnProfileId(activeId);
+            setApnProfiles(profiles.map(p => ({ ...p, isDefault: p.id === activeId })));
+        } catch (e) { }
+    };
+
+    // Ethernet handlers
+    const handleEthernetModeChange = async (mode: EthernetMode) => {
+        if (!networkSettingsService || isChangingEthernet) return;
+
+        const changed = mode !== ethernetMode;
+
+        setIsChangingEthernet(true);
+        try {
+            await networkSettingsService.setEthernetConnectionMode(mode);
+            setEthernetMode(mode);
+            const settings = await networkSettingsService.getEthernetSettings();
+            setEthernetStatus(settings.status);
+            ThemedAlertHelper.alert(t('common.success'), t('networkSettings.profileSaved'));
+            if (changed) {
+                showInterstitial(() => { });
+            }
+        } catch (error) {
+            ThemedAlertHelper.alert(t('common.error'), t('common.error'));
+        } finally {
+            setIsChangingEthernet(false);
+        }
+    };
+
+    // DHCP handlers
+    const handleDHCPToggle = async (enabled: boolean) => {
+        if (!networkSettingsService || isTogglingDhcp) return;
+        setIsTogglingDhcp(true);
+        try {
+            await networkSettingsService.toggleDHCPServer(enabled);
+            setDhcpSettings(prev => ({ ...prev, dhcpStatus: enabled }));
+        } catch (error) {
+            ThemedAlertHelper.alert(t('common.error'), t('networkSettings.failedSaveDhcp'));
+        } finally {
+            setIsTogglingDhcp(false);
+        }
+    };
+
+    const handleSaveDHCPSettings = async () => {
+        if (!networkSettingsService || isSavingDhcp) return;
+        setIsSavingDhcp(true);
+        try {
+            await networkSettingsService.setDHCPSettings(dhcpSettings);
+            showInterstitial(() => {
+                ThemedAlertHelper.alert(t('common.success'), t('networkSettings.dhcpSaved'));
+            });
+        } catch (error) {
+            ThemedAlertHelper.alert(t('common.error'), t('networkSettings.failedSaveDhcp'));
+        } finally {
+            setIsSavingDhcp(false);
+        }
+    };
+
+    const getLeaseTimeLabel = (seconds: number): string => {
+        if (seconds <= 3600) return t('networkSettings.leaseTime1Hour');
+        if (seconds <= 43200) return t('networkSettings.leaseTime12Hours');
+        if (seconds <= 86400) return t('networkSettings.leaseTime1Day');
+        return t('networkSettings.leaseTime1Week');
+    };
+
+    // APN handlers
+    const openAddApnModal = () => {
+        setEditingApn(null);
+        setShowApnModal(true);
+    };
+
+    const openEditApnModal = (profile: any) => {
+        setEditingApn(profile);
+        setShowApnModal(true);
+    };
+
+    const handleSaveApnProfile = async (profileData: any) => {
+        if (!networkSettingsService || isSavingApn) return;
+        setIsSavingApn(true);
+        try {
+            const data = {
+                ...profileData,
+                readOnly: false,
+            };
+
+            if (editingApn) {
+                await networkSettingsService.updateAPNProfile({ id: editingApn.id, ...data });
+            } else {
+                await networkSettingsService.createAPNProfile(data);
+            }
+            setShowApnModal(false);
+            showInterstitial(() => {
+                ThemedAlertHelper.alert(t('common.success'), t('networkSettings.apnSaved'));
+            });
+            setTimeout(() => loadApn(networkSettingsService), 2000);
+        } catch (error) {
+            ThemedAlertHelper.alert(t('common.error'), t('common.error'));
+        } finally {
+            setIsSavingApn(false);
+        }
+    };
+
+    const handleDeleteApnProfile = (profileId: string) => {
+        const profile = apnProfiles.find(p => p.id === profileId);
+        const profileName = profile?.name || profileId;
+
+        ThemedAlertHelper.alert(
+            t('networkSettings.deleteProfile'),
+            t('networkSettings.deleteProfileConfirm', { name: profileName }),
+            [
+                { text: t('common.cancel'), style: 'cancel' },
+                {
+                    text: t('common.delete'),
+                    style: 'destructive',
+                    onPress: async () => {
+                        try {
+                            await networkSettingsService?.deleteAPNProfile(profileId);
+                            ThemedAlertHelper.alert(t('common.success'), t('networkSettings.apnDeleted'));
+                            if (networkSettingsService) loadApn(networkSettingsService);
+                        } catch (error) {
+                            ThemedAlertHelper.alert(t('common.error'), t('networkSettings.deleteApnFailed'));
+                        }
+                    },
+                },
+            ]
+        );
+    };
+
+    const handleSetDefaultApn = async (profileId: string) => {
+        const profile = apnProfiles.find(p => p.id === profileId);
+        const profileName = profile?.name || profileId;
+
+        ThemedAlertHelper.alert(
+            t('networkSettings.switchProfile'),
+            t('networkSettings.switchProfileConfirm', { name: profileName }),
+            [
+                { text: t('common.cancel'), style: 'cancel' },
+                {
+                    text: t('common.confirm'),
+                    onPress: async () => {
+                        try {
+                            await networkSettingsService?.setActiveAPNProfile(profileId);
+                            if (networkSettingsService) loadApn(networkSettingsService);
+                            ThemedAlertHelper.alert(t('common.success'), t('networkSettings.profileSwitched'));
+                        } catch (e) {
+                            ThemedAlertHelper.alert(t('common.error'), t('common.error'));
+                        }
+                    },
+                },
+            ]
+        );
+    };
+
+    return {
+        // Ethernet
+        ethernetMode,
+        ethernetStatus,
+        isChangingEthernet,
+        showEthernetModal,
+        setShowEthernetModal,
+        handleEthernetModeChange,
+
+        // DHCP
+        dhcpSettings,
+        setDhcpSettings,
+        isTogglingDhcp,
+        isSavingDhcp,
+        showLeaseTimeDropdown,
+        setShowLeaseTimeDropdown,
+        handleDHCPToggle,
+        handleSaveDHCPSettings,
+        getLeaseTimeLabel,
+
+        // APN
+        apnProfiles,
+        activeApnProfileId,
+        showApnModal,
+        setShowApnModal,
+        editingApn,
+        setEditingApn,
+        isSavingApn,
+        openAddApnModal,
+        openEditApnModal,
+        handleSaveApnProfile,
+        handleDeleteApnProfile,
+        handleSetDefaultApn,
+    };
+}

--- a/src/hooks/settings/useMobileNetwork.ts
+++ b/src/hooks/settings/useMobileNetwork.ts
@@ -1,0 +1,222 @@
+import { useState, useEffect } from 'react';
+import { useAuthStore } from '@/stores/auth.store';
+import { ModemService } from '@/services/modem.service';
+import { ThemedAlertHelper, getSelectedBandsDisplay } from '@/components';
+import { showInterstitial } from '@/services/ad.service';
+
+interface UseMobileNetworkProps {
+    t: (key: string, options?: any) => string;
+}
+
+export function useMobileNetwork({ t }: UseMobileNetworkProps) {
+    const { credentials } = useAuthStore();
+    const [modemService, setModemService] = useState<ModemService | null>(null);
+
+    const [mobileDataEnabled, setMobileDataEnabled] = useState(false);
+    const [dataRoamingEnabled, setDataRoamingEnabled] = useState(false);
+    const [autoNetworkEnabled, setAutoNetworkEnabled] = useState(true);
+
+    const [isTogglingMobileData, setIsTogglingMobileData] = useState(false);
+    const [isTogglingRoaming, setIsTogglingRoaming] = useState(false);
+    const [isTogglingAutoNetwork, setIsTogglingAutoNetwork] = useState(false);
+
+    const [networkMode, setNetworkMode] = useState('00');
+    const [showNetworkModeModal, setShowNetworkModeModal] = useState(false);
+    const [isChangingNetwork, setIsChangingNetwork] = useState(false);
+
+    const [showBandModal, setShowBandModal] = useState(false);
+    const [selectedBandsDisplay, setSelectedBandsDisplay] = useState<string[]>([]);
+
+    const [showMonthlyModal, setShowMonthlyModal] = useState(false);
+    const [showSignalPointingModal, setShowSignalPointingModal] = useState(false);
+    const [monthlySettings, setMonthlySettings] = useState({
+        enabled: false,
+        startDay: 1,
+        dataLimit: 0,
+        dataLimitUnit: 'GB' as 'MB' | 'GB',
+        monthThreshold: 90,
+    });
+
+    useEffect(() => {
+        if (credentials?.modemIp) {
+            const service = new ModemService(credentials.modemIp);
+            setModemService(service);
+            loadSettings(service);
+        }
+    }, [credentials]);
+
+    const loadSettings = async (service: ModemService) => {
+        try {
+            const [mobileData, roaming, autoNetwork, netMode, bandSettings, mSettings] = await Promise.all([
+                service.getMobileDataStatus(),
+                service.getDataRoamingStatus(),
+                service.getAutoNetworkStatus(),
+                service.getNetworkMode(),
+                service.getBandSettings(),
+                service.getMonthlyDataSettings(),
+            ]);
+
+            setMobileDataEnabled(mobileData.isEnabled);
+            setDataRoamingEnabled(roaming);
+            setAutoNetworkEnabled(autoNetwork);
+            setNetworkMode(netMode);
+
+            if (bandSettings?.lteBand) {
+                setSelectedBandsDisplay(getSelectedBandsDisplay(bandSettings.lteBand));
+            }
+
+            setMonthlySettings({
+                enabled: mSettings.enabled,
+                startDay: mSettings.startDay,
+                dataLimit: mSettings.dataLimit,
+                dataLimitUnit: mSettings.dataLimitUnit,
+                monthThreshold: mSettings.monthThreshold,
+            });
+
+        } catch (error) {
+            console.error('Error loading mobile network settings:', error);
+        }
+    };
+
+    const handleSaveMonthlySettings = async (settings: any) => {
+        if (!modemService) return;
+        try {
+            await modemService.setMonthlyDataSettings(settings);
+            setMonthlySettings(settings);
+            showInterstitial(() => {
+                ThemedAlertHelper.alert(t('common.success'), t('home.monthlySettingsSaved'));
+            });
+        } catch (error) {
+            ThemedAlertHelper.alert(t('common.error'), t('home.failedSaveMonthlySettings'));
+        }
+    };
+
+    const handleToggleMobileData = async (value: boolean) => {
+        if (!modemService || isTogglingMobileData) return;
+
+        if (!value) {
+            ThemedAlertHelper.alert(
+                t('settings.mobileData'),
+                t('home.confirmDisableData'),
+                [
+                    { text: t('common.cancel'), style: 'cancel' },
+                    {
+                        text: t('common.turnOff'),
+                        style: 'destructive',
+                        onPress: () => executeToggleMobileData(value)
+                    }
+                ]
+            );
+        } else {
+            executeToggleMobileData(value);
+        }
+    };
+
+    const executeToggleMobileData = async (value: boolean) => {
+        if (!modemService) return;
+        setIsTogglingMobileData(true);
+        try {
+            await modemService.toggleMobileData(value);
+            setMobileDataEnabled(value);
+            showInterstitial(() => { });
+        } catch (error) {
+            ThemedAlertHelper.alert(t('common.error'), t('alerts.failedToggleData'));
+            setMobileDataEnabled(!value);
+        } finally {
+            setIsTogglingMobileData(false);
+        }
+    };
+
+    const handleToggleRoaming = async (value: boolean) => {
+        if (!modemService || isTogglingRoaming) return;
+        setIsTogglingRoaming(true);
+        try {
+            await modemService.setDataRoaming(value);
+            setDataRoamingEnabled(value);
+            showInterstitial(() => { });
+        } catch (error) {
+            ThemedAlertHelper.alert(t('common.error'), t('common.error'));
+            setDataRoamingEnabled(!value);
+        } finally {
+            setIsTogglingRoaming(false);
+        }
+    };
+
+    const handleToggleAutoNetwork = async (value: boolean) => {
+        if (!modemService || isTogglingAutoNetwork) return;
+        setIsTogglingAutoNetwork(true);
+        try {
+            await modemService.setAutoNetwork(value);
+            setAutoNetworkEnabled(value);
+            showInterstitial(() => { });
+        } catch (error) {
+            ThemedAlertHelper.alert(t('common.error'), t('common.error'));
+            setAutoNetworkEnabled(!value);
+        } finally {
+            setIsTogglingAutoNetwork(false);
+        }
+    };
+
+    const handleNetworkModeChange = async (mode: string) => {
+        if (!modemService) return;
+
+        const changed = mode !== networkMode;
+
+        setShowNetworkModeModal(false);
+        setIsChangingNetwork(true);
+        try {
+            await modemService.setNetworkMode(mode);
+            setNetworkMode(mode);
+            ThemedAlertHelper.alert(t('common.success'), t('settings.networkModeChanged'));
+            if (changed) {
+                showInterstitial(() => { });
+            }
+        } catch (error: any) {
+            let errorMessage = t('alerts.failedChangeNetwork');
+            if (error?.huaweiErrorCode === '100003') {
+                errorMessage = t('alerts.networkModeNotSupported') || 'Preferred network mode selection is not supported on this modem.';
+            }
+            ThemedAlertHelper.alert(t('common.error'), errorMessage);
+        } finally {
+            setIsChangingNetwork(false);
+        }
+    };
+
+    return {
+        modemService,
+        loadSettings,
+
+        // Data toggles
+        mobileDataEnabled,
+        dataRoamingEnabled,
+        autoNetworkEnabled,
+        isTogglingMobileData,
+        isTogglingRoaming,
+        isTogglingAutoNetwork,
+        handleToggleMobileData,
+        handleToggleRoaming,
+        handleToggleAutoNetwork,
+
+        // Network mode
+        networkMode,
+        showNetworkModeModal,
+        setShowNetworkModeModal,
+        isChangingNetwork,
+        handleNetworkModeChange,
+
+        // Band
+        showBandModal,
+        setShowBandModal,
+        selectedBandsDisplay,
+
+        // Monthly
+        showMonthlyModal,
+        setShowMonthlyModal,
+        monthlySettings,
+        handleSaveMonthlySettings,
+
+        // Signal pointing
+        showSignalPointingModal,
+        setShowSignalPointingModal,
+    };
+}

--- a/src/hooks/settings/useSystemSettings.ts
+++ b/src/hooks/settings/useSystemSettings.ts
@@ -1,0 +1,320 @@
+import { useState, useEffect } from 'react';
+import { useRouter } from 'expo-router';
+import { useAuthStore } from '@/stores/auth.store';
+import { useThemeStore } from '@/stores/theme.store';
+import { useModemProfileStore } from '@/stores/modem-profile.store';
+import { ModemService } from '@/services/modem.service';
+import { ThemedAlertHelper } from '@/components';
+import { showInterstitial } from '@/services/ad.service';
+import { getModemProfilePassword } from '@/utils/storage';
+
+interface UseSystemSettingsProps {
+    t: (key: string, options?: any) => string;
+}
+
+const formatModemTime = (time: string) => {
+    if (!time) return '...';
+    try {
+        if (time.includes('T')) {
+            const dateObj = new Date(time);
+            if (!isNaN(dateObj.getTime())) {
+                const year = dateObj.getFullYear();
+                const month = String(dateObj.getMonth() + 1).padStart(2, '0');
+                const day = String(dateObj.getDate()).padStart(2, '0');
+                const hours = String(dateObj.getHours()).padStart(2, '0');
+                const minutes = String(dateObj.getMinutes()).padStart(2, '0');
+                const seconds = String(dateObj.getSeconds()).padStart(2, '0');
+                return `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`;
+            }
+            const parts = time.split('T');
+            const datePart = parts[0];
+            const timePart = parts[1]?.split('.')[0].replace('Z', '');
+            return `${datePart} ${timePart}`;
+        }
+
+        let cleaned = time.replace(',', '');
+        const parts = cleaned.split(' ');
+        if (parts.length < 2) return time.replace(/\//g, '-');
+
+        let datePart = parts[0];
+        let timePart = parts[1];
+
+        timePart = timePart.replace(/\./g, ':');
+
+        if (datePart.includes('/')) {
+            const dateSegments = datePart.split('/');
+            if (dateSegments[2].length === 4) {
+                datePart = `${dateSegments[2]}-${dateSegments[1]}-${dateSegments[0]}`;
+            } else {
+                datePart = datePart.replace(/\//g, '-');
+            }
+        }
+
+        return `${datePart} ${timePart}`;
+
+    } catch (e) {
+        return time;
+    }
+};
+
+export function useSystemSettings({ t }: UseSystemSettingsProps) {
+    const router = useRouter();
+    const { credentials, login, logout } = useAuthStore();
+    const { profiles, loadProfiles, deleteProfile, updateProfile, switchProfile, isSwitching } = useModemProfileStore();
+
+    // Profile edit state
+    const [showEditProfile, setShowEditProfile] = useState(false);
+    const [editingProfile, setEditingProfile] = useState<{ id: string; name: string; modemIp: string; username: string; password: string } | null>(null);
+
+    useEffect(() => { loadProfiles(); }, []);
+
+    const [modemService, setModemService] = useState<ModemService | null>(null);
+
+    // Time settings
+    const [currentTime, setCurrentTime] = useState('');
+    const [sntpEnabled, setSntpEnabled] = useState(true);
+    const [ntpServer, setNtpServer] = useState('pool.ntp.org');
+    const [timezone, setTimezone] = useState('UTC+7');
+    const [showTimezoneModal, setShowTimezoneModal] = useState(false);
+    const [isTogglingSntp, setIsTogglingSntp] = useState(false);
+
+    // Credentials
+    const [modemIp, setModemIp] = useState(credentials?.modemIp || '192.168.8.1');
+    const [modemUsername, setModemUsername] = useState(credentials?.username || 'admin');
+    const [modemPassword, setModemPassword] = useState(credentials?.password || '');
+    const [showPassword, setShowPassword] = useState(false);
+    const [isSavingCredentials, setIsSavingCredentials] = useState(false);
+
+    const hasCredentialsChanges =
+        modemIp !== (credentials?.modemIp || '192.168.8.1') ||
+        modemUsername !== (credentials?.username || 'admin') ||
+        modemPassword !== (credentials?.password || '');
+
+    useEffect(() => {
+        if (credentials?.modemIp) {
+            const service = new ModemService(credentials.modemIp);
+            setModemService(service);
+            loadTime(service);
+
+            const interval = setInterval(() => {
+                service.getCurrentTime().then(setTime => setCurrentTime(setTime)).catch(() => { });
+            }, 1000);
+            return () => clearInterval(interval);
+        }
+    }, [credentials]);
+
+    const loadTime = async (service: ModemService) => {
+        try {
+            const settings = await service.getTimeSettings();
+            setCurrentTime(settings.currentTime);
+            setSntpEnabled(settings.sntpEnabled);
+            setNtpServer(settings.ntpServer);
+            setTimezone(settings.timezone);
+        } catch (e) { }
+    };
+
+    const handleToggleSntp = async (enabled: boolean) => {
+        if (!modemService || isTogglingSntp) return;
+        setIsTogglingSntp(true);
+        try {
+            await modemService.setTimeSettings({ sntpEnabled: enabled });
+            setSntpEnabled(enabled);
+            showInterstitial(() => {});
+        } catch (error) {
+            ThemedAlertHelper.alert(t('common.error'), t('common.error'));
+        } finally {
+            setIsTogglingSntp(false);
+        }
+    };
+
+    const handleTimezoneChange = async (tz: string) => {
+        if (!modemService) return;
+        setShowTimezoneModal(false);
+        try {
+            await modemService.setTimeSettings({ timezone: tz });
+            setTimezone(tz);
+            showInterstitial(() => {});
+        } catch (error) {
+            ThemedAlertHelper.alert(t('common.error'), t('common.error'));
+        }
+    };
+
+    const handleSaveCredentials = async () => {
+        if (isSavingCredentials) return;
+        setIsSavingCredentials(true);
+        try {
+            await login({
+                modemIp,
+                username: modemUsername,
+                password: modemPassword,
+            });
+            showInterstitial(() => {
+                ThemedAlertHelper.alert(t('common.success'), t('settings.credentialsSaved'));
+                router.replace('/settings');
+            });
+        } catch (error) {
+            ThemedAlertHelper.alert(t('common.error'), t('settings.failedSaveCredentials'));
+        } finally {
+            setIsSavingCredentials(false);
+        }
+    };
+
+    const handleReboot = async () => {
+        ThemedAlertHelper.alert(
+            t('settings.rebootModem'),
+            t('settings.rebootConfirm'),
+            [
+                { text: t('common.cancel'), style: 'cancel' },
+                {
+                    text: t('settings.rebootModem'),
+                    style: 'destructive',
+                    onPress: async () => {
+                        if (modemService) {
+                            try {
+                                await modemService.reboot();
+                                showInterstitial(() => {
+                                    ThemedAlertHelper.alert(t('common.success'), t('settings.rebootSuccess'));
+                                });
+                            } catch (e) {
+                                ThemedAlertHelper.alert(t('common.error'), t('alerts.failedReboot'));
+                            }
+                        }
+                    }
+                }
+            ]
+        );
+    };
+
+    const handleLogout = async () => {
+        ThemedAlertHelper.alert(
+            t('settings.logout'),
+            t('settings.logoutConfirm'),
+            [
+                { text: t('common.cancel'), style: 'cancel' },
+                {
+                    text: t('settings.logout'),
+                    style: 'destructive',
+                    onPress: async () => {
+                        try {
+                            if (modemService) await modemService.logout();
+                        } catch (e) { }
+                        await logout();
+                        router.replace('/login');
+                    }
+                }
+            ]
+        );
+    };
+
+    const handleReset = async () => {
+        ThemedAlertHelper.alert(
+            t('settings.resetFactory'),
+            t('settings.resetConfirm'),
+            [
+                { text: t('common.cancel'), style: 'cancel' },
+                {
+                    text: t('settings.resetFactory'),
+                    style: 'destructive',
+                    onPress: async () => {
+                        if (modemService) {
+                            try {
+                                await modemService.resetFactorySettings();
+                                showInterstitial(() => {
+                                    ThemedAlertHelper.alert(t('common.success'), t('settings.resetSuccess'));
+                                });
+                            } catch (e) {
+                                ThemedAlertHelper.alert(t('common.error'), t('alerts.failedReset'));
+                            }
+                        }
+                    }
+                }
+            ]
+        );
+    };
+
+    const handleOpenEditProfile = async (profile: any) => {
+        const pwd = await getModemProfilePassword(profile.id);
+        setEditingProfile({
+            id: profile.id,
+            name: profile.name,
+            modemIp: profile.modemIp,
+            username: profile.username,
+            password: pwd,
+        });
+        setShowEditProfile(true);
+    };
+
+    const handleSwitchProfile = (profile: any) => {
+        ThemedAlertHelper.alert(
+            t('settings.switchProfile'),
+            t('settings.switchProfileConfirm').replace('{{name}}', profile.name),
+            [
+                { text: t('common.cancel'), style: 'cancel' },
+                {
+                    text: t('settings.switchProfile'),
+                    onPress: async () => {
+                        const success = await switchProfile(profile.id);
+                        if (success) {
+                            ThemedAlertHelper.alert(
+                                t('common.success'),
+                                t('settings.switchSuccess').replace('{{name}}', profile.name)
+                            );
+                        } else {
+                            const err = useModemProfileStore.getState().switchError;
+                            const details = err ? `\n\nError: ${err}` : '';
+                            ThemedAlertHelper.alert(
+                                t('common.error'),
+                                t('settings.switchFailed') + details
+                            );
+                        }
+                    }
+                },
+            ]
+        );
+    };
+
+    const handleDeleteProfile = (profile: any) => {
+        ThemedAlertHelper.alert(
+            t('settings.deleteProfile'),
+            t('settings.deleteProfileConfirm').replace('{{name}}', profile.name),
+            [
+                { text: t('common.cancel'), style: 'cancel' },
+                {
+                    text: t('common.delete'),
+                    style: 'destructive',
+                    onPress: () => deleteProfile(profile.id),
+                },
+            ]
+        );
+    };
+
+    return {
+        // Time
+        currentTime,
+        formattedTime: formatModemTime(currentTime),
+        sntpEnabled,
+        timezone,
+        showTimezoneModal,
+        setShowTimezoneModal,
+        isTogglingSntp,
+        handleToggleSntp,
+        handleTimezoneChange,
+
+        // Profiles
+        profiles,
+        showEditProfile,
+        setShowEditProfile,
+        editingProfile,
+        setEditingProfile,
+        isSwitching,
+        updateProfile,
+        handleOpenEditProfile,
+        handleSwitchProfile,
+        handleDeleteProfile,
+
+        // Actions
+        handleReboot,
+        handleLogout,
+        handleReset,
+    };
+}

--- a/src/hooks/settings/useUpdateCheck.ts
+++ b/src/hooks/settings/useUpdateCheck.ts
@@ -1,0 +1,175 @@
+import { useState, useEffect, useCallback } from 'react';
+import Animated, {
+    useAnimatedStyle,
+    useSharedValue,
+    withRepeat,
+    withTiming,
+    Easing,
+    cancelAnimation
+} from 'react-native-reanimated';
+import Constants from 'expo-constants';
+
+const GITHUB_OWNER = 'alrescha79-cmd';
+const GITHUB_REPO = 'huawei-manager-mobile';
+
+export interface ReleaseInfo {
+    tagName: string;
+    version: string;
+    downloadUrl: string;
+    releaseNotes: string;
+    publishedAt: string;
+    isPreRelease: boolean;
+}
+
+/**
+ * Compare semantic versions.
+ * Returns: 1 if v1 > v2, -1 if v1 < v2, 0 if equal
+ */
+function compareVersions(v1: string, v2: string): number {
+    const normalize = (v: string) => v.replace(/^v/, '').replace(/-.*$/, '').split('.').map(n => parseInt(n, 10) || 0);
+    const parts1 = normalize(v1);
+    const parts2 = normalize(v2);
+
+    for (let i = 0; i < Math.max(parts1.length, parts2.length); i++) {
+        const p1 = parts1[i] || 0;
+        const p2 = parts2[i] || 0;
+        if (p1 > p2) return 1;
+        if (p1 < p2) return -1;
+    }
+    return 0;
+}
+
+export function useUpdateCheck() {
+    const [checking, setChecking] = useState(false);
+    const [updateAvailable, setUpdateAvailable] = useState(false);
+    const [releaseInfo, setReleaseInfo] = useState<ReleaseInfo | null>(null);
+    const [preReleaseInfo, setPreReleaseInfo] = useState<ReleaseInfo | null>(null);
+    const [preReleaseAvailable, setPreReleaseAvailable] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [hasChecked, setHasChecked] = useState(false);
+
+    // Rotation animation for sync icon
+    const rotation = useSharedValue(0);
+
+    const animatedStyle = useAnimatedStyle(() => ({
+        transform: [{ rotate: `${rotation.value}deg` }],
+    }));
+
+    useEffect(() => {
+        if (checking) {
+            rotation.value = 0;
+            rotation.value = withRepeat(
+                withTiming(360, { duration: 1000, easing: Easing.linear }),
+                -1,
+                false
+            );
+        } else {
+            cancelAnimation(rotation);
+            rotation.value = 0;
+        }
+    }, [checking]);
+
+    useEffect(() => {
+        checkUpdate();
+    }, []);
+
+    const checkUpdate = useCallback(async () => {
+        setChecking(true);
+        setError(null);
+        setUpdateAvailable(false);
+        setPreReleaseAvailable(false);
+        setReleaseInfo(null);
+        setPreReleaseInfo(null);
+
+        try {
+            const response = await fetch(
+                `https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/releases`,
+                {
+                    headers: {
+                        'Accept': 'application/vnd.github.v3+json',
+                    },
+                }
+            );
+
+            if (!response.ok) {
+                throw new Error(`GitHub API error: ${response.status}`);
+            }
+
+            const releases = await response.json();
+            const currentVersion = Constants.expoConfig?.version || '0.0.0';
+
+            const stableRelease = releases.find((r: any) => !r.prerelease && !r.draft);
+            const preRelease = releases.find((r: any) => r.prerelease && !r.draft);
+
+            const parseRelease = (data: any, isPreRelease: boolean): ReleaseInfo => {
+                const apkAsset = data.assets?.find((asset: any) =>
+                    asset.name?.endsWith('.apk') || asset.name?.includes('universal')
+                );
+
+                let version = '';
+                const tagName = data.tag_name || '';
+
+                const semverMatch = tagName.match(/v?(\d+\.\d+\.\d+)/);
+                if (semverMatch) {
+                    version = semverMatch[1];
+                } else {
+                    const nameMatch = (data.name || '').match(/v?(\d+\.\d+\.\d+)/);
+                    if (nameMatch) {
+                        version = nameMatch[1];
+                    } else if (apkAsset?.name) {
+                        const assetMatch = apkAsset.name.match(/v?(\d+\.\d+\.\d+)/);
+                        if (assetMatch) {
+                            version = assetMatch[1];
+                        }
+                    }
+                }
+
+                return {
+                    tagName: tagName,
+                    version: version,
+                    downloadUrl: apkAsset?.browser_download_url || data.html_url || '',
+                    releaseNotes: data.body || '',
+                    publishedAt: data.published_at || '',
+                    isPreRelease,
+                };
+            };
+
+            if (stableRelease) {
+                const info = parseRelease(stableRelease, false);
+                setReleaseInfo(info);
+                const comparison = compareVersions(info.version, currentVersion);
+                setUpdateAvailable(comparison > 0);
+            }
+
+            if (preRelease) {
+                const info = parseRelease(preRelease, true);
+                setPreReleaseInfo(info);
+                const comparison = info.version ? compareVersions(info.version, currentVersion) : 1;
+                setPreReleaseAvailable(comparison > 0);
+            }
+
+            setHasChecked(true);
+        } catch (err) {
+            console.error('Update check failed:', err);
+            setError(err instanceof Error ? err.message : 'Unknown error');
+            setHasChecked(true);
+        } finally {
+            setChecking(false);
+        }
+    }, []);
+
+    const availableCount = (updateAvailable ? 1 : 0) + (preReleaseAvailable ? 1 : 0);
+
+    return {
+        checking,
+        updateAvailable,
+        releaseInfo,
+        preReleaseInfo,
+        preReleaseAvailable,
+        error,
+        hasChecked,
+        animatedStyle,
+        availableCount,
+        checkUpdate,
+    };
+}

--- a/src/hooks/settings/useUpdateDownload.ts
+++ b/src/hooks/settings/useUpdateDownload.ts
@@ -1,0 +1,140 @@
+import { useState, useRef } from 'react';
+import { Platform, Linking } from 'react-native';
+import * as FileSystem from 'expo-file-system/legacy';
+import { ThemedAlertHelper } from '@/components';
+
+let IntentLauncher: any = null;
+try {
+    IntentLauncher = require('expo-intent-launcher');
+} catch (e) {
+    console.warn('expo-intent-launcher is not available in this environment:', e);
+}
+
+interface UseUpdateDownloadProps {
+    t: (key: string, options?: any) => string;
+}
+
+export function useUpdateDownload({ t }: UseUpdateDownloadProps) {
+    const [downloading, setDownloading] = useState(false);
+    const [downloadProgress, setDownloadProgress] = useState(0);
+    const [downloadResumable, setDownloadResumable] = useState<FileSystem.DownloadResumable | null>(null);
+    const isCancelledRef = useRef(false);
+
+    const handleDownloadAndInstall = async (url: string, versionName: string) => {
+        if (Platform.OS !== 'android') {
+            Linking.openURL(url);
+            return;
+        }
+
+        try {
+            setDownloading(true);
+            setDownloadProgress(0);
+            isCancelledRef.current = false;
+
+            const filename = `huawei-manager-v${versionName}.apk`;
+            const localUri = `${FileSystem.cacheDirectory}${filename}`;
+
+            const fileInfo = await FileSystem.getInfoAsync(localUri);
+            if (fileInfo.exists) {
+                await FileSystem.deleteAsync(localUri, { idempotent: true });
+            }
+
+            const resumable = FileSystem.createDownloadResumable(
+                url,
+                localUri,
+                {},
+                (downloadProgressData) => {
+                    const progress = downloadProgressData.totalBytesWritten / downloadProgressData.totalBytesExpectedToWrite;
+                    setDownloadProgress(Math.round(progress * 100));
+                }
+            );
+
+            setDownloadResumable(resumable);
+
+            const result = await resumable.downloadAsync();
+            setDownloading(false);
+            setDownloadResumable(null);
+
+            if (result && result.uri) {
+                let launched = false;
+                if (Platform.OS === 'android') {
+                    try {
+                        const contentUri = await FileSystem.getContentUriAsync(result.uri);
+                        if (IntentLauncher && IntentLauncher.startActivityAsync) {
+                            await IntentLauncher.startActivityAsync('android.intent.action.VIEW', {
+                                data: contentUri,
+                                type: 'application/vnd.android.package-archive',
+                                flags: 1, // FLAG_GRANT_READ_URI_PERMISSION
+                            });
+                            launched = true;
+                        }
+                    } catch (e) {
+                        console.warn('Failed to launch APK installation intent:', e);
+                    }
+                }
+
+                if (!launched) {
+                    ThemedAlertHelper.alert(
+                        t('common.success') || 'Success',
+                        t('settings.downloadComplete') || 'Update downloaded successfully. Please open and install the APK file manually, or open the link in your browser.',
+                        [
+                            { text: t('common.ok') || 'OK' },
+                            { text: t('settings.downloadUpdate') || 'Open Browser', onPress: () => Linking.openURL(url) }
+                        ]
+                    );
+                }
+            } else {
+                throw new Error('Download failed: result is empty');
+            }
+        } catch (err: any) {
+            if (isCancelledRef.current) {
+                isCancelledRef.current = false;
+                return;
+            }
+            console.error('Download/Install failed:', err);
+            setDownloading(false);
+            setDownloadResumable(null);
+
+            const message = err instanceof Error ? err.message : String(err);
+            ThemedAlertHelper.alert(
+                t('common.error') || 'Error',
+                `${t('settings.downloadFailed') || 'Failed to download or install update. Please try again or download manually.'}\n\n${message}`,
+                [
+                    { text: t('common.ok') || 'OK' },
+                    { text: t('settings.downloadUpdate') || 'Open Browser', onPress: () => Linking.openURL(url) }
+                ]
+            );
+        }
+    };
+
+    const handleCancelDownload = async () => {
+        if (downloadResumable) {
+            try {
+                isCancelledRef.current = true;
+                await downloadResumable.cancelAsync();
+                setDownloading(false);
+                setDownloadProgress(0);
+                setDownloadResumable(null);
+                ThemedAlertHelper.alert(
+                    t('settings.downloadCancelledTitle') || 'Cancelled',
+                    t('settings.downloadCancelledMessage') || 'Download cancelled.'
+                );
+            } catch (e) {
+                console.error('Error cancelling download:', e);
+                isCancelledRef.current = false;
+                const message = e instanceof Error ? e.message : String(e);
+                ThemedAlertHelper.alert(
+                    t('common.error') || 'Error',
+                    `${t('settings.downloadFailed') || 'Failed to download or install update. Please try again or download manually.'}\n\n${message}`
+                );
+            }
+        }
+    };
+
+    return {
+        downloading,
+        downloadProgress,
+        handleDownloadAndInstall,
+        handleCancelDownload,
+    };
+}

--- a/src/hooks/sms/index.ts
+++ b/src/hooks/sms/index.ts
@@ -1,0 +1,3 @@
+export * from './useSMSData';
+export * from './useSMSActions';
+export * from './useMessageLinks';

--- a/src/hooks/sms/useMessageLinks.tsx
+++ b/src/hooks/sms/useMessageLinks.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { Text, Linking } from 'react-native';
+import { useTheme } from '@/theme';
+
+/**
+ * Hook that provides a function to render SMS message content
+ * with clickable URL links.
+ */
+export function useMessageLinks() {
+    const { colors, typography } = useTheme();
+
+    const renderMessageWithLinks = (content: string) => {
+        const urlRegex = /(https?:\/\/[^\s]+)|(www\.[^\s]+)|([a-zA-Z0-9][-a-zA-Z0-9]*\.[a-zA-Z]{2,}(?:\/[^\s]*)?)/gi;
+
+        const parts = content.split(urlRegex).filter(Boolean);
+
+        if (parts.length === 1 && !urlRegex.test(content)) {
+            return (
+                <Text style={[typography.body, { color: colors.text, lineHeight: 22 }]}>
+                    {content}
+                </Text>
+            );
+        }
+
+        urlRegex.lastIndex = 0;
+
+        const elements: React.ReactNode[] = [];
+        let lastIndex = 0;
+        let match;
+        let key = 0;
+
+        while ((match = urlRegex.exec(content)) !== null) {
+            if (match.index > lastIndex) {
+                elements.push(
+                    <Text key={key++} style={[typography.body, { color: colors.text, lineHeight: 22 }]}>
+                        {content.substring(lastIndex, match.index)}
+                    </Text>
+                );
+            }
+
+            const url = match[0];
+            const fullUrl = url.startsWith('http') ? url : `https://${url}`;
+
+            elements.push(
+                <Text
+                    key={key++}
+                    style={[typography.body, { color: colors.primary, lineHeight: 22, textDecorationLine: 'underline' }]}
+                    onPress={() => Linking.openURL(fullUrl)}
+                >
+                    {url}
+                </Text>
+            );
+
+            lastIndex = match.index + match[0].length;
+        }
+
+        if (lastIndex < content.length) {
+            elements.push(
+                <Text key={key++} style={[typography.body, { color: colors.text, lineHeight: 22 }]}>
+                    {content.substring(lastIndex)}
+                </Text>
+            );
+        }
+
+        return <Text>{elements}</Text>;
+    };
+
+    return { renderMessageWithLinks };
+}

--- a/src/hooks/sms/useSMSActions.ts
+++ b/src/hooks/sms/useSMSActions.ts
@@ -1,0 +1,233 @@
+import { useState } from 'react';
+import { SMSService } from '@/services/sms.service';
+import { ThemedAlertHelper } from '@/components';
+import { SMSMessage } from '@/types';
+
+interface UseSMSActionsProps {
+    smsService: SMSService | null;
+    messages: SMSMessage[];
+    filteredMessages: SMSMessage[];
+    removeMessage: (index: string) => void;
+    handleRefresh: () => void;
+    t: (key: string, options?: any) => string;
+}
+
+export function useSMSActions({
+    smsService,
+    messages,
+    filteredMessages,
+    removeMessage,
+    handleRefresh,
+    t,
+}: UseSMSActionsProps) {
+    // Compose state
+    const [showCompose, setShowCompose] = useState(false);
+    const [newPhone, setNewPhone] = useState('');
+    const [newMessage, setNewMessage] = useState('');
+    const [isSending, setIsSending] = useState(false);
+
+    // Detail state
+    const [selectedMessage, setSelectedMessage] = useState<SMSMessage | null>(null);
+    const [showDetail, setShowDetail] = useState(false);
+    const [replyMessage, setReplyMessage] = useState('');
+
+    // Selection state
+    const [isSelectionMode, setIsSelectionMode] = useState(false);
+    const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+
+    const handleDelete = async (index: string) => {
+        if (!smsService) return;
+
+        ThemedAlertHelper.alert(
+            t('sms.deleteSms'),
+            t('sms.deleteConfirm'),
+            [
+                { text: t('common.cancel'), style: 'cancel' },
+                {
+                    text: t('common.delete'),
+                    style: 'destructive',
+                    onPress: async () => {
+                        try {
+                            await smsService.deleteSMS(index);
+                            removeMessage(index);
+                            ThemedAlertHelper.alert(t('common.success'), t('sms.messageDeleted'));
+                        } catch (error) {
+                            ThemedAlertHelper.alert(t('common.error'), t('alerts.failedDeleteSms'));
+                        }
+                    },
+                },
+            ]
+        );
+    };
+
+    const handleLongPress = (message: SMSMessage) => {
+        if (!isSelectionMode) {
+            setIsSelectionMode(true);
+            setSelectedIds(new Set([`${message.boxType}-${message.index}`]));
+        }
+    };
+
+    const toggleSelect = (message: SMSMessage) => {
+        const id = `${message.boxType}-${message.index}`;
+        setSelectedIds(prev => {
+            const newSet = new Set(prev);
+            if (newSet.has(id)) {
+                newSet.delete(id);
+            } else {
+                newSet.add(id);
+            }
+            return newSet;
+        });
+    };
+
+    const handleSelectAll = () => {
+        if (selectedIds.size === filteredMessages.length) {
+            setSelectedIds(new Set());
+        } else {
+            const allIds = filteredMessages.map(m => `${m.boxType}-${m.index}`);
+            setSelectedIds(new Set(allIds));
+        }
+    };
+
+    const exitSelectionMode = () => {
+        setIsSelectionMode(false);
+        setSelectedIds(new Set());
+    };
+
+    const handleDeleteSelected = async () => {
+        if (!smsService || selectedIds.size === 0) return;
+
+        ThemedAlertHelper.alert(
+            t('sms.deleteSelected'),
+            t('sms.deleteSelectedConfirm', { count: selectedIds.size }),
+            [
+                { text: t('common.cancel'), style: 'cancel' },
+                {
+                    text: t('common.delete'),
+                    style: 'destructive',
+                    onPress: async () => {
+                        try {
+                            const idsToDelete = Array.from(selectedIds);
+                            for (const id of idsToDelete) {
+                                const index = id.split('-').slice(1).join('-');
+                                await smsService.deleteSMS(index);
+                                removeMessage(index);
+                            }
+                            ThemedAlertHelper.alert(
+                                t('common.success'),
+                                t('sms.messagesDeleted', { count: idsToDelete.length })
+                            );
+                            exitSelectionMode();
+                        } catch (error) {
+                            ThemedAlertHelper.alert(t('common.error'), t('alerts.failedDeleteSms'));
+                        }
+                    },
+                },
+            ]
+        );
+    };
+
+    const handleSend = async () => {
+        if (!smsService || !newPhone || !newMessage) {
+            ThemedAlertHelper.alert(t('common.error'), t('sms.fillAllFields'));
+            return;
+        }
+
+        setIsSending(true);
+        try {
+            await smsService.sendSMS(newPhone, newMessage);
+            ThemedAlertHelper.alert(t('common.success'), t('sms.messageSent'));
+            setShowCompose(false);
+            setNewPhone('');
+            setNewMessage('');
+            handleRefresh();
+        } catch (error) {
+            ThemedAlertHelper.alert(t('common.error'), t('alerts.failedSendSms'));
+        } finally {
+            setIsSending(false);
+        }
+    };
+
+    const handleOpenDetail = async (message: SMSMessage) => {
+        setSelectedMessage(message);
+        setReplyMessage('');
+        setShowDetail(true);
+
+        if (smsService && message.smstat === '0') {
+            try {
+                await smsService.markAsRead(message.index);
+            } catch (error) {
+                console.error('Failed to mark SMS as read:', error);
+            }
+        }
+    };
+
+    const handleReply = async () => {
+        if (!smsService || !selectedMessage || !replyMessage) {
+            ThemedAlertHelper.alert(t('common.error'), t('sms.fillAllFields'));
+            return;
+        }
+
+        setIsSending(true);
+        try {
+            await smsService.sendSMS(selectedMessage.phone, replyMessage);
+            ThemedAlertHelper.alert(t('common.success'), t('sms.messageSent'));
+            setReplyMessage('');
+            setShowDetail(false);
+            setSelectedMessage(null);
+            handleRefresh();
+        } catch (error) {
+            ThemedAlertHelper.alert(t('common.error'), t('alerts.failedSendSms'));
+        } finally {
+            setIsSending(false);
+        }
+    };
+
+    const handleMarkAllAsRead = async () => {
+        if (!smsService) return;
+        const unreadMessages = messages.filter(m => m.smstat === '0');
+        for (const msg of unreadMessages) {
+            try {
+                await smsService.markAsRead(msg.index);
+            } catch (error) {
+                console.error('Failed to mark SMS as read:', error);
+            }
+        }
+        handleRefresh();
+    };
+
+    return {
+        // Compose
+        showCompose,
+        setShowCompose,
+        newPhone,
+        setNewPhone,
+        newMessage,
+        setNewMessage,
+        isSending,
+        handleSend,
+
+        // Detail
+        selectedMessage,
+        setSelectedMessage,
+        showDetail,
+        setShowDetail,
+        replyMessage,
+        setReplyMessage,
+        handleOpenDetail,
+        handleReply,
+
+        // Selection
+        isSelectionMode,
+        selectedIds,
+        handleLongPress,
+        toggleSelect,
+        handleSelectAll,
+        exitSelectionMode,
+        handleDeleteSelected,
+
+        // Actions
+        handleDelete,
+        handleMarkAllAsRead,
+    };
+}

--- a/src/hooks/sms/useSMSData.ts
+++ b/src/hooks/sms/useSMSData.ts
@@ -1,0 +1,203 @@
+import { useState, useEffect } from 'react';
+import { AppState } from 'react-native';
+import { useAuthStore } from '@/stores/auth.store';
+import { useSMSStore } from '@/stores/sms.store';
+import { SMSService } from '@/services/sms.service';
+import { checkNewSMSNotification } from '@/services/notification.service';
+import { SMSMessage } from '@/types';
+
+type SMSFilterType = 'all' | 'unread' | 'sent';
+
+interface UseSMSDataProps {
+    t: (key: string, options?: any) => string;
+}
+
+export function useSMSData({ t }: UseSMSDataProps) {
+    const { credentials } = useAuthStore();
+    const {
+        messages,
+        smsCount,
+        setMessages,
+        setSMSCount,
+        removeMessage,
+    } = useSMSStore();
+
+    const [isRefreshing, setIsRefreshing] = useState(false);
+    const [smsService, setSMSService] = useState<SMSService | null>(null);
+    const [smsSupported, setSmsSupported] = useState(true);
+    const [searchQuery, setSearchQuery] = useState('');
+    const [messageFilter, setMessageFilter] = useState<SMSFilterType>('all');
+
+    useEffect(() => {
+        if (credentials?.modemIp) {
+            const service = new SMSService(credentials.modemIp);
+            setSMSService(service);
+
+            service.resetSMSCache();
+
+            loadData(service);
+
+            const intervalId = setInterval(() => {
+                if (AppState.currentState === 'active') {
+                    loadDataSilent(service);
+                }
+            }, 10000);
+
+            return () => clearInterval(intervalId);
+        }
+    }, [credentials]);
+
+    const loadData = async (service: SMSService) => {
+        try {
+            setIsRefreshing(true);
+
+            let isSupported = false;
+            try {
+                isSupported = await service.isSMSSupported();
+            } catch (error: any) {
+                if (error?.message?.includes('125003') || error?.message?.includes('125002')) {
+                    const { requestRelogin } = useAuthStore.getState();
+                    requestRelogin();
+                }
+                setSmsSupported(false);
+                return;
+            }
+
+            if (!isSupported) {
+                setSmsSupported(false);
+                setMessages([]);
+                setSMSCount({
+                    localUnread: 0,
+                    localInbox: 0,
+                    localOutbox: 0,
+                    localDraft: 0,
+                    simUnread: 0,
+                    simInbox: 0,
+                    simOutbox: 0,
+                    simDraft: 0,
+                    newMsg: 0,
+                    localDeleted: 0,
+                    simDeleted: 0,
+                    localMax: 0,
+                    simMax: 0,
+                });
+                return;
+            }
+
+            try {
+                const [inboxMessages, count] = await Promise.all([
+                    service.getSMSList(1, 20, 1),
+                    service.getSMSCount(),
+                ]);
+
+                let sentMessages: typeof inboxMessages = [];
+                try {
+                    if (count.localOutbox > 0) {
+                        sentMessages = await service.getSMSList(1, 20, 2);
+                    }
+                } catch (outboxError) {
+                    console.log('Outbox loading skipped:', outboxError);
+                }
+
+                const allMessages = [...inboxMessages, ...sentMessages].sort(
+                    (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
+                );
+
+                setMessages(allMessages);
+                setSMSCount(count);
+                setSmsSupported(true);
+
+                if (count.localUnread > 0) {
+                    checkNewSMSNotification(count.localUnread, {
+                        title: t('notifications.newSms'),
+                        body: (n) => t('notifications.newSmsBody', { count: n }),
+                    });
+                }
+            } catch (error: any) {
+                if (error?.message?.includes('125003') || error?.message?.includes('125002')) {
+                    const { requestRelogin } = useAuthStore.getState();
+                    requestRelogin();
+                } else {
+                    setSmsSupported(false);
+                }
+            }
+        } finally {
+            setIsRefreshing(false);
+        }
+    };
+
+    const loadDataSilent = async (service: SMSService) => {
+        try {
+            const isSupported = await service.isSMSSupported();
+            if (!isSupported) {
+                setSmsSupported(false);
+                return;
+            }
+
+            try {
+                const [inboxMessages, count] = await Promise.all([
+                    service.getSMSList(1, 20, 1),
+                    service.getSMSCount(),
+                ]);
+
+                let sentMessages: typeof inboxMessages = [];
+                try {
+                    if (count.localOutbox > 0) {
+                        sentMessages = await service.getSMSList(1, 20, 2);
+                    }
+                } catch {
+                }
+
+                const allMessages = [...inboxMessages, ...sentMessages].sort(
+                    (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
+                );
+
+                setMessages(allMessages);
+                setSMSCount(count);
+            } catch (error: any) {
+                if (error?.message?.includes('125003') || error?.message?.includes('125002')) {
+                    const { requestRelogin } = useAuthStore.getState();
+                    requestRelogin();
+                }
+            }
+        } catch (error: any) {
+            if (error?.message?.includes('125003') || error?.message?.includes('125002')) {
+                const { requestRelogin } = useAuthStore.getState();
+                requestRelogin();
+            }
+        }
+    };
+
+    const handleRefresh = () => {
+        if (smsService) {
+            loadData(smsService);
+        }
+    };
+
+    const filteredMessages = messages.filter(msg => {
+        if (messageFilter === 'unread' && msg.smstat !== '0') return false;
+        if (messageFilter === 'sent' && msg.boxType !== 2) return false;
+
+        if (!searchQuery.trim()) return true;
+        const query = searchQuery.toLowerCase();
+        return (
+            msg.phone.toLowerCase().includes(query) ||
+            msg.content.toLowerCase().includes(query)
+        );
+    });
+
+    return {
+        isRefreshing,
+        smsService,
+        smsSupported,
+        searchQuery,
+        setSearchQuery,
+        messageFilter,
+        setMessageFilter,
+        messages,
+        smsCount,
+        removeMessage,
+        filteredMessages,
+        handleRefresh,
+    };
+}

--- a/src/hooks/useLogin.ts
+++ b/src/hooks/useLogin.ts
@@ -1,0 +1,293 @@
+import { useState, useEffect } from 'react';
+import { Linking } from 'react-native';
+import { useRouter } from 'expo-router';
+import Constants from 'expo-constants';
+import * as Device from 'expo-device';
+import * as MailComposer from 'expo-mail-composer';
+import { useAuthStore } from '@/stores/auth.store';
+import { useModemProfileStore } from '@/stores/modem-profile.store';
+import { getModemProfilePassword } from '@/utils/storage';
+import { networkService } from '@/services/network.service';
+import { ModemAPIClient } from '@/services/api.service';
+import { ThemedAlertHelper } from '@/components';
+import { ModemProfile } from '@/types';
+
+interface UseLoginProps {
+    t: (key: string, options?: any) => string;
+}
+
+export function useLogin({ t }: UseLoginProps) {
+    const router = useRouter();
+    const { login, isLoading, error, setError, credentials, loadCredentials } = useAuthStore();
+    const { profiles, loadProfiles, addProfile, ensureProfile } = useModemProfileStore();
+
+    const [modemIp, setModemIp] = useState('192.168.8.1');
+    const [username, setUsername] = useState('admin');
+    const [password, setPassword] = useState('');
+    const [isDetecting, setIsDetecting] = useState(false);
+    const [showWebViewLogin, setShowWebViewLogin] = useState(false);
+    const [isDirectLogging, setIsDirectLogging] = useState(false);
+    const [showWebViewOption, setShowWebViewOption] = useState(false);
+    const [isAutoLoginReady, setIsAutoLoginReady] = useState(false);
+    const [selectedProfileId, setSelectedProfileId] = useState<string | null>(null);
+    const [showAddProfile, setShowAddProfile] = useState(false);
+    const [newProfileName, setNewProfileName] = useState('');
+    const [isSavingProfile, setIsSavingProfile] = useState(false);
+
+    useEffect(() => {
+        const initCredentials = async () => {
+            await loadCredentials();
+            await loadProfiles();
+            setIsAutoLoginReady(true);
+        };
+        initCredentials();
+    }, []);
+
+    useEffect(() => {
+        if (isAutoLoginReady && credentials) {
+            const active = profiles.find((p) => p.isActive);
+            if (active) {
+                setSelectedProfileId(active.id);
+            }
+            setModemIp(credentials.modemIp || '192.168.8.1');
+            setUsername(credentials.username || 'admin');
+            setPassword(credentials.password || '');
+        }
+    }, [isAutoLoginReady, credentials]);
+
+    const selectProfile = async (profile: ModemProfile) => {
+        setSelectedProfileId(profile.id);
+        setModemIp(profile.modemIp);
+        setUsername(profile.username);
+        const pwd = await getModemProfilePassword(profile.id);
+        setPassword(pwd);
+        setError(null);
+        setShowWebViewOption(false);
+    };
+
+    const handleSaveProfile = async () => {
+        if (!newProfileName.trim()) {
+            ThemedAlertHelper.alert(t('common.error'), t('settings.profileName') + ' ' + t('common.error').toLowerCase());
+            return;
+        }
+        if (profiles.length >= 5) {
+            ThemedAlertHelper.alert(t('common.error'), t('settings.profileLimitReached'));
+            return;
+        }
+        setIsSavingProfile(true);
+        const result = await addProfile({
+            name: newProfileName.trim(),
+            modemIp,
+            username,
+            password,
+        });
+        setIsSavingProfile(false);
+        if (result) {
+            setNewProfileName('');
+            setShowAddProfile(false);
+            setSelectedProfileId(result.id);
+        }
+    };
+
+    const detectModemIP = async () => {
+        setIsDetecting(true);
+        try {
+            const isWiFi = await networkService.isConnectedToWiFi();
+
+            if (!isWiFi) {
+                ThemedAlertHelper.alert(
+                    t('login.wifiRequired'),
+                    t('login.wifiRequiredMessage')
+                );
+                setIsDetecting(false);
+                return;
+            }
+
+            const detectedIP = await networkService.detectGatewayIP();
+            setModemIp(detectedIP);
+        } catch (err) {
+            console.error('Error detecting modem IP:', err);
+        } finally {
+            setIsDetecting(false);
+        }
+    };
+
+    const handleLoginPress = async () => {
+        setError(null);
+        setShowWebViewOption(false);
+
+        if (!modemIp) {
+            ThemedAlertHelper.alert(t('common.error'), t('login.enterModemIp'));
+            return;
+        }
+
+        setIsDirectLogging(true);
+
+        const apiClient = new ModemAPIClient(modemIp);
+        let success = false;
+
+        for (let attempt = 1; attempt <= 3; attempt++) {
+            try {
+                console.log(`[Login Page] Attempt ${attempt}/3...`);
+                success = await apiClient.login(username, password);
+
+                if (success) {
+                    console.log('[Login Page] Direct login successful!');
+                    await login({
+                        modemIp,
+                        username,
+                        password,
+                    });
+                    await ensureProfile({ modemIp, username, password });
+                    setIsDirectLogging(false);
+                    router.replace('/(tabs)/home');
+                    return;
+                }
+            } catch (err: any) {
+                console.log(`[Login Page] Attempt ${attempt} failed:`, err.message);
+                if (attempt < 3) {
+                    await new Promise(resolve => setTimeout(resolve, 500));
+                }
+            }
+        }
+
+        setIsDirectLogging(false);
+
+        setShowWebViewOption(true);
+        ThemedAlertHelper.alert(
+            t('login.directLoginFailed'),
+            t('login.directLoginFailedMessage'),
+            [
+                { text: t('common.cancel'), style: 'cancel' },
+                { text: t('login.openWebLogin'), onPress: () => setShowWebViewLogin(true) }
+            ]
+        );
+    };
+
+    const handleWebViewLoginSuccess = async () => {
+        setShowWebViewLogin(false);
+
+        try {
+            await login({
+                modemIp,
+                username,
+                password,
+            });
+            await ensureProfile({ modemIp, username, password });
+
+            ThemedAlertHelper.alert(t('common.success'), t('login.loginSuccess'), [
+                {
+                    text: t('common.ok'),
+                    onPress: () => router.replace('/(tabs)/home'),
+                },
+            ]);
+        } catch (err) {
+            console.error('[Login] Error saving credentials:', err);
+            const errorMessage = err instanceof Error ? err.message : t('login.loginFailed');
+            ThemedAlertHelper.alert(t('common.error'), errorMessage);
+            setError(errorMessage);
+        }
+    };
+
+    const handleReportIssue = async () => {
+        const deviceString = `${Device.manufacturer || ''} ${Device.modelName || 'Unknown Device'}`.trim();
+        const osString = `${Device.osName || 'Unknown OS'} ${Device.osVersion || ''}`;
+        const appVersion = Constants.expoConfig?.version || '1.0.0';
+        const dateString = new Date().toLocaleDateString();
+
+        const reportTemplate = `=== BUG REPORT / FEATURE REQUEST ===
+
+📱 Device: ${deviceString}
+📲 OS: ${osString}
+📦 App Version: ${appVersion}
+🔧 Modem IP: ${modemIp || 'Not set'}
+📅 Date: ${dateString}
+
+---
+
+📝 Description (please fill in):
+[Describe the issue you're experiencing. Include any error messages you see.]
+
+🔄 Steps to Reproduce:
+1. Open App
+2. Enter credentials
+3. [What happens next?]
+
+---
+`;
+
+        const emailSubject = `[Huawei Manager] Login Issue - ${deviceString}`;
+        const githubTitle = encodeURIComponent(`Login Issue - ${deviceString}`);
+        const githubBody = encodeURIComponent(reportTemplate);
+        const githubUrl = `https://github.com/alrescha79-cmd/huawei-manager-mobile/issues/new?title=${githubTitle}&body=${githubBody}`;
+
+        ThemedAlertHelper.alert(
+            t('login.reportIssue'),
+            t('login.reportIssueMessage'),
+            [
+                { text: t('common.cancel'), style: 'cancel' },
+                {
+                    text: 'GitHub Issue',
+                    onPress: () => {
+                        Linking.openURL(githubUrl).catch(() => {
+                            ThemedAlertHelper.alert(t('common.error'), 'Could not open GitHub');
+                        });
+                    }
+                },
+                {
+                    text: 'Email',
+                    onPress: async () => {
+                        const isAvailable = await MailComposer.isAvailableAsync();
+                        if (isAvailable) {
+                            await MailComposer.composeAsync({
+                                recipients: ['anggun@cakson.my.id'],
+                                subject: emailSubject,
+                                body: reportTemplate,
+                            });
+                        } else {
+                            const mailtoUrl = `mailto:anggun@cakson.my.id?subject=${encodeURIComponent(emailSubject)}&body=${encodeURIComponent(reportTemplate)}`;
+                            Linking.openURL(mailtoUrl).catch(() => {
+                                ThemedAlertHelper.alert(t('common.error'), 'Could not open email client');
+                            });
+                        }
+                    }
+                }
+            ]
+        );
+    };
+
+    return {
+        // Form state
+        modemIp,
+        setModemIp,
+        username,
+        setUsername,
+        password,
+        setPassword,
+        error,
+        isLoading,
+        isDetecting,
+        isDirectLogging,
+        showWebViewLogin,
+        setShowWebViewLogin,
+        showWebViewOption,
+        setShowWebViewOption,
+
+        // Profile state
+        profiles,
+        selectedProfileId,
+        showAddProfile,
+        setShowAddProfile,
+        newProfileName,
+        setNewProfileName,
+        isSavingProfile,
+
+        // Handlers
+        selectProfile,
+        handleSaveProfile,
+        detectModemIP,
+        handleLoginPress,
+        handleWebViewLoginSuccess,
+        handleReportIssue,
+    };
+}


### PR DESCRIPTION
Extract API interactions, state management, and handlers from screen components to enforce the thin-screen pattern:
- Move SMS logic to useSMSData, useSMSActions, and useMessageLinks
- Move update logic to useUpdateCheck and useUpdateDownload
- Move login logic to useLogin
- Move settings logic to useSystemSettings, useLanSettings, and useMobileNetwork
- Reduce overall screen file sizes in src/app by ~47%