### PR TITLE
feat(ui): add in-app webview and revamp update modals

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -40,7 +40,7 @@ export default ({ config }: ConfigContext): ExpoConfig => {
         ...config,
         name: isDev ? 'HM Mobile [DEV]' : 'Huawei Manager',
         slug: 'hm-mobile',
-        version: '1.1.60',
+        version: '1.1.65',
         orientation: 'portrait',
         icon: './assets/logo.png',
         userInterfaceStyle: 'automatic',

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,12 @@
 # EN
 
+## v1.1.65
+- **Signal Bubble Monitoring** Added a floating Signal Bubble for quick monitoring of signal quality and internet speed without leaving the current screen.
+- **Expanded Quick Actions** Added more shortcut buttons to Quick Actions, making common modem and network controls faster to access from the home dashboard.
+- **Settings Update Improvements** Improved the Settings > Update flow for a clearer update-checking experience, better release information display, and smoother navigation.
+- **GitHub WebView** Added a WebView screen for browsing GitHub links inside the app.
+- **Minor Bug Fixes** Fixed several minor bugs across the app for improved stability and a smoother experience.
+
 ## v1.1.55
 - **5G Network Support** Added full support for 5G NR signal metrics (RSRP, RSRQ, SINR) and multi-band Carrier Aggregation (e.g. B3 + B1 + N40) band display.
 - **Enhanced WiFi Devices List** Dynamically reads connection frequencies (2.4 GHz / 5 GHz) and connection types using the HostInfo API. Device icons are now automatically mapped based on VendorClassID (Android, Apple, Windows).
@@ -13,6 +20,13 @@
 - **Background Resource & Ad Optimization** Suspends background updates and widget polling to save battery when backgrounded, with capped App Open ad frequency and improved interstitial flow.
 
 # ID
+
+## v1.1.65
+- **Monitoring Signal Bubble** Menambahkan Signal Bubble melayang untuk memantau kualitas sinyal dan kecepatan internet dengan cepat tanpa perlu berpindah dari layar yang sedang dibuka.
+- **Penambahan Tombol Quick Actions** Menambahkan lebih banyak tombol pintasan pada Quick Actions agar kontrol modem dan jaringan yang sering digunakan bisa diakses lebih cepat dari dashboard utama.
+- **Perbaikan Settings > Update** Menyempurnakan alur Settings > Update agar proses pengecekan pembaruan lebih jelas, informasi rilis lebih mudah dibaca, dan navigasi terasa lebih lancar.
+- **WebView GitHub** Menambahkan layar WebView untuk membuka halaman GitHub di dalam aplikasi.
+- **Perbaikan Bug Minor** Memperbaiki beberapa bug minor di berbagai bagian aplikasi untuk meningkatkan stabilitas dan pengalaman yang lebih lancar.
 
 ## v1.1.55
 - **Dukungan Jaringan 5G** Penambahan dukungan penuh untuk metrik sinyal 5G NR (RSRP, RSRQ, SINR) dan tampilan Carrier Aggregation multi-band (misal: B3 + B1 + N40).

--- a/docs/HUAWEI_LTE_API_ENDPOINTS.md
+++ b/docs/HUAWEI_LTE_API_ENDPOINTS.md
@@ -1,7 +1,7 @@
 # Huawei LTE API — Pemetaan Endpoint Lengkap
 
-> **Sumber:** Reverse Engineering 
-> **Base URL:** `http://<router-ip>/api/`  
+> **Sumber:** Reverse Engineering    
+> **Base URL:** `http://<router-ip>`  
 > **Format request/response:** XML  
 > **Autentikasi:** Wajib login dulu, semua request butuh header `__RequestVerificationToken`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hm-mobile",
-  "version": "1.1.60",
+  "version": "1.1.65",
   "main": "index.js",
   "scripts": {
     "start": "expo start",

--- a/src/app/(tabs)/home.tsx
+++ b/src/app/(tabs)/home.tsx
@@ -20,7 +20,6 @@ import { formatBytes, formatDuration, DurationUnits } from '@/utils/helpers';
 import { useTranslation } from '@/i18n';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
-// Custom Hooks
 import { useHomeAuth } from '@/hooks/home/useHomeAuth';
 import { useHomeData } from '@/hooks/home/useHomeData';
 import { useHomeActions } from '@/hooks/home/useHomeActions';
@@ -65,7 +64,7 @@ export default function HomeScreen() {
   const [showMonthlySettingsModal, setShowMonthlySettingsModal] = useState(false);
   const [showSpeedTestModal, setShowSpeedTestModal] = useState(false);
   const [showSignalPointingModal, setShowSignalPointingModal] = useState(false);
-  // Hook Initialization
+
   const {
     showReloginWebView,
     setShowReloginWebView,
@@ -81,16 +80,14 @@ export default function HomeScreen() {
     setRelogging,
     clearSessionExpired,
     tryQuietSessionRestore,
-    modemService: null, // Will be updated by useHomeData if needed, but we can pass it down. 
-    // Wait! Let's just pass modemService from useHomeData to useHomeAuth!
+    modemService: null, 
     t,
-    loadData: async () => { }, // mock initially
+    loadData: async () => { }, 
     loadBands: async () => { },
   });
 
   const homeData = useHomeData({ t, showReloginWebView });
 
-  // Re-bind the correct modemService to useHomeAuth functions
   const homeAuth = useHomeAuth({
     credentials,
     logout,

--- a/src/app/(tabs)/settings/index.tsx
+++ b/src/app/(tabs)/settings/index.tsx
@@ -22,7 +22,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 export default function SettingsIndex() {
     const router = useRouter();
-    const { colors, typography } = useTheme();
+    const { colors, typography, isDark } = useTheme();
     const { t } = useTranslation();
     const { themeMode, setThemeMode, language, setLanguage, usageCardStyle, setUsageCardStyle, accentColor, setAccentColor, signalBubbleEnabled, setSignalBubbleEnabled } = useThemeStore();
     const insets = useSafeAreaInsets();
@@ -37,7 +37,7 @@ export default function SettingsIndex() {
     const { debugEnabled, setDebugEnabled, apiLogs, sendDebugEmail, clearLogs, shareDebugLog } = useDebugStore();
 
     const handleOpenGitHub = () => {
-        Linking.openURL('https://github.com/alrescha79-cmd');
+        router.push({ pathname: '/webview', params: { url: 'https://github.com/alrescha79-cmd', title: t('settings.developer') || 'Developer' } });
     };
 
     const getThemeLabel = (mode: string) => {
@@ -118,6 +118,7 @@ export default function SettingsIndex() {
                             icon="data-usage"
                             title="Data Usage View"
                             onPress={() => setShowUsageModal(true)}
+                            showChevron={false}
                             rightElement={
                                 <TouchableOpacity
                                     style={[styles.dropdownTrigger, { backgroundColor: colors.card, borderColor: colors.border }]}
@@ -134,6 +135,7 @@ export default function SettingsIndex() {
                             icon="brightness-6"
                             title={t('settings.theme')}
                             onPress={() => setShowThemeModal(true)}
+                            showChevron={false}
                             rightElement={
                                 <TouchableOpacity
                                     style={[styles.dropdownTrigger, { backgroundColor: colors.card, borderColor: colors.border }]}
@@ -151,6 +153,7 @@ export default function SettingsIndex() {
                             icon="palette"
                             title={t('settings.accentColor')}
                             onPress={() => setShowAccentModal(true)}
+                            showChevron={false}
                             rightElement={
                                 <TouchableOpacity
                                     style={[styles.dropdownTrigger, { backgroundColor: colors.card, borderColor: colors.border }]}
@@ -169,6 +172,7 @@ export default function SettingsIndex() {
                             icon="translate"
                             title={t('settings.language')}
                             onPress={() => setShowLanguageModal(true)}
+                            showChevron={false}
                             rightElement={
                                 <TouchableOpacity
                                     style={[styles.dropdownTrigger, { backgroundColor: colors.card, borderColor: colors.border }]}
@@ -201,7 +205,7 @@ export default function SettingsIndex() {
                             icon="bug-report"
                             title={t('settings.bugReport')}
                             subtitle={t('settings.bugReportHint')}
-                            onPress={() => Linking.openURL('https://github.com/alrescha79-cmd/huawei-manager-mobile/issues')}
+                            onPress={() => router.push({ pathname: '/webview', params: { url: 'https://github.com/alrescha79-cmd/huawei-manager-mobile/issues', title: t('settings.bugReport') || 'Bug Report' } })}
                             isLast
                         />
                     </SettingsSection>
@@ -411,6 +415,7 @@ export default function SettingsIndex() {
                         options={Object.entries(ACCENT_PRESETS).map(([key, preset]) => ({
                             label: preset.label,
                             value: key,
+                            color: isDark ? preset.dark : preset.light,
                         }))}
                         selectedValue={accentColor}
                         onSelect={(val) => {

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -10,7 +10,7 @@ import * as SplashScreen from 'expo-splash-screen';
 import { useAuthStore } from '@/stores/auth.store';
 import { useThemeStore } from '@/stores/theme.store';
 import { useTheme } from '@/theme';
-import { ThemedAlert, setAlertListener, ThemedAlertHelper, AnimatedSplashScreen, AdBlockAlertModal, ChangelogModal, ChangelogHelper, SignalBubble } from '@/components';
+import { UpdateAvailableModal, UpdateAvailableHelper, ThemedAlert, setAlertListener, ThemedAlertHelper, AnimatedSplashScreen, AdBlockAlertModal, ChangelogModal, ChangelogHelper, SignalBubble } from '@/components';
 import { useTranslation } from '@/i18n';
 import { startRealtimeWidgetUpdates, stopRealtimeWidgetUpdates } from '@/widget';
 import { isSessionLikelyValid } from '@/utils/storage';
@@ -135,17 +135,9 @@ export default function RootLayout() {
             const currentVersion = Constants.expoConfig?.version || '1.1.50';
 
             if (compareVersions(latestVersion, currentVersion) > 0) {
-                ThemedAlertHelper.alert(
-                    t('settings.updateAvailable') + ` v${latestVersion}`,
-                    t('alerts.newVersionAvailable'),
-                    [
-                        { text: t('common.cancel'), style: 'cancel' },
-                        {
-                            text: t('settings.downloadUpdate'),
-                            onPress: () => router.push('/settings/update')
-                        },
-                    ]
-                );
+                setTimeout(() => {
+                    UpdateAvailableHelper.show(latestVersion);
+                }, 3500);
             }
         } catch (error) {
             console.error('Error checking for updates:', error);
@@ -386,10 +378,11 @@ export default function RootLayout() {
         if (!fontsLoaded || !authReady) return;
 
         const inAuthGroup = segments[0] === '(tabs)';
+        const inWebview = segments[0] === 'webview';
 
         if (!isAuthenticated && inAuthGroup) {
             router.replace('/login');
-        } else if (isAuthenticated && !inAuthGroup) {
+        } else if (isAuthenticated && !inAuthGroup && !inWebview) {
             router.replace('/(tabs)/home');
         }
     }, [isAuthenticated, segments, fontsLoaded, authReady]);
@@ -432,6 +425,13 @@ export default function RootLayout() {
                             headerShown: false,
                         }}
                     />
+                    <Stack.Screen
+                        name="webview"
+                        options={{
+                            headerShown: false,
+                            presentation: 'modal',
+                        }}
+                    />
                 </Stack>
 
                 <ThemedAlert
@@ -443,7 +443,8 @@ export default function RootLayout() {
                 />
 
                 <AdBlockAlertModal />
-                <ChangelogModal />
+                <UpdateAvailableModal onDownload={() => router.push('/settings/update')} />
+<ChangelogModal />
                 {isAuthenticated && signalBubbleEnabled && <SignalBubble />}
             </KeyboardProvider>
         </GestureHandlerRootView>

--- a/src/app/webview.tsx
+++ b/src/app/webview.tsx
@@ -1,0 +1,55 @@
+import React, { useState } from 'react';
+import { StyleSheet, View, ActivityIndicator } from 'react-native';
+import { WebView } from 'react-native-webview';
+import { useLocalSearchParams } from 'expo-router';
+import { useTheme } from '@/theme';
+import { PageHeader } from '@/components/settings';
+import { AnimatedScreen } from '@/components';
+
+export default function GenericWebViewScreen() {
+    const { colors } = useTheme();
+    const { url, title } = useLocalSearchParams<{ url: string; title: string }>();
+    const [isLoading, setIsLoading] = useState(true);
+
+    return (
+        <AnimatedScreen>
+            <View style={[styles.container, { backgroundColor: colors.background }]}>
+                <PageHeader 
+                    title={title || 'Browser'} 
+                    showBackButton={true}
+                />
+                <View style={styles.content}>
+                    <WebView
+                        source={{ uri: url || 'https://google.com' }}
+                        style={styles.webview}
+                        onLoadStart={() => setIsLoading(true)}
+                        onLoadEnd={() => setIsLoading(false)}
+                    />
+                    {isLoading && (
+                        <View style={[styles.loadingContainer, { backgroundColor: colors.background }]}>
+                            <ActivityIndicator size="large" color={colors.primary} />
+                        </View>
+                    )}
+                </View>
+            </View>
+        </AnimatedScreen>
+    );
+}
+
+const styles = StyleSheet.create({
+    container: {
+        flex: 1,
+    },
+    content: {
+        flex: 1,
+        position: 'relative',
+    },
+    webview: {
+        flex: 1,
+    },
+    loadingContainer: {
+        ...StyleSheet.absoluteFillObject,
+        justifyContent: 'center',
+        alignItems: 'center',
+    },
+});

--- a/src/components/ChangelogModal.tsx
+++ b/src/components/ChangelogModal.tsx
@@ -17,6 +17,7 @@ import { useTranslation } from '@/i18n';
 import { Ionicons } from '@expo/vector-icons';
 import Constants from 'expo-constants';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useRouter } from 'expo-router';
 import CHANGELOG_MD from '../../changelog.md';
 
 interface ChangelogModalProps {
@@ -49,8 +50,9 @@ export const ChangelogModal: React.FC<ChangelogModalProps> = () => {
     const { t, language } = useTranslation();
     const [slideAnim] = useState(new Animated.Value(0));
     const insets = useSafeAreaInsets();
+    const router = useRouter();
 
-    const currentVersion = Constants.expoConfig?.version || '1.1.28';
+    const currentVersion = Constants.expoConfig?.version || '1.1.60';
     const GITHUB_REPO_URL = 'https://github.com/alrescha79-cmd/huawei-manager-mobile';
     const RELEASE_URL = `${GITHUB_REPO_URL}/releases/tag/v${currentVersion}`;
 
@@ -101,6 +103,15 @@ export const ChangelogModal: React.FC<ChangelogModalProps> = () => {
             const content = isBullet ? line.trim().replace(/^[-*]\s+/, '') : line.trim();
 
             if (!content) return null;
+
+            const headingMatch = content.match(/^##\s+(.+)/);
+            if (headingMatch) {
+                return (
+                    <Text key={lineIndex} style={[typography.title3, styles.versionTitle, { color: colors.text }]}>
+                        {headingMatch[1]}
+                    </Text>
+                );
+            }
 
             // Match **Header** Description
             const boldMatch = content.match(/^\*\*(.*?)\*\*(.*)/);
@@ -221,12 +232,14 @@ export const ChangelogModal: React.FC<ChangelogModalProps> = () => {
                     </View>
 
                     <Text style={[typography.headline, styles.title, { color: colors.text }]}>
-                        {language === 'id' ? 'Berhasil Diperbarui!' : 'Successfully Updated!'}
+                        {t('changelog.title')}
                     </Text>
 
                     <Text style={[typography.subheadline, styles.subtitle, { color: colors.primary, fontWeight: '700' }]}>
                         v{currentVersion}
                     </Text>
+
+                    <View style={{ height: 1, backgroundColor: colors.border }} />
 
                     <View style={styles.scrollArea}>
                         <ScrollView showsVerticalScrollIndicator={false} contentContainerStyle={styles.scrollContent}>
@@ -238,24 +251,26 @@ export const ChangelogModal: React.FC<ChangelogModalProps> = () => {
                         <TouchableOpacity
                             style={[styles.primaryButton, { borderRadius: borderRadius.md, backgroundColor: colors.primary }]}
                             activeOpacity={0.8}
-                            onPress={async () => {
-                                Linking.openURL(GITHUB_REPO_URL);
+                            onPress={() => {
+                                handleClose();
+                                router.push({ pathname: '/webview', params: { url: GITHUB_REPO_URL, title: t('changelog.giveStar') } });
                             }}
                         >
                             <Text style={styles.primaryButtonText}>
-                                {language === 'id' ? 'Beri Bintang' : 'Give Star'}
+                                {t('changelog.giveStar')}
                             </Text>
                         </TouchableOpacity>
 
                         <TouchableOpacity
                             style={[styles.outlineButton, { borderRadius: borderRadius.md, borderColor: colors.border }]}
                             activeOpacity={0.7}
-                            onPress={async () => {
-                                Linking.openURL(RELEASE_URL);
+                            onPress={() => {
+                                handleClose();
+                                router.push({ pathname: '/webview', params: { url: RELEASE_URL, title: t('changelog.fullChangelog') } });
                             }}
                         >
                             <Text style={[typography.body, styles.outlineButtonText, { color: colors.text }]}>
-                                {language === 'id' ? 'Lihat Changelog Lengkap' : 'View Full Changelog'}
+                                {t('changelog.fullChangelog')}
                             </Text>
                         </TouchableOpacity>
 
@@ -265,7 +280,7 @@ export const ChangelogModal: React.FC<ChangelogModalProps> = () => {
                             onPress={handleClose}
                         >
                             <Text style={[typography.body, styles.closeButtonText, { color: colors.textSecondary }]}>
-                                {language === 'id' ? 'Lanjutkan' : 'Continue'}
+                                {t('changelog.continue')}
                             </Text>
                         </TouchableOpacity>
                     </View>
@@ -337,6 +352,11 @@ const styles = StyleSheet.create({
     },
     scrollContent: {
         flexGrow: 1,
+    },
+    versionTitle: {
+        fontWeight: '800',
+        marginTop: 8,
+        marginBottom: 12,
     },
     bulletRow: {
         flexDirection: 'row',

--- a/src/components/SelectionModal.tsx
+++ b/src/components/SelectionModal.tsx
@@ -17,6 +17,7 @@ import { ModalBackground } from './ModalBackground';
 export interface SelectionOption {
     label: string;
     value: string | number;
+    color?: string;
 }
 
 interface SelectionModalProps {
@@ -83,15 +84,20 @@ export function SelectionModal({
                                     onPress={() => onSelect(option.value)}
                                     activeOpacity={0.7}
                                 >
-                                    <Text style={[
-                                        styles.modalItemText,
-                                        {
-                                            color: isSelected ? colors.primary : colors.text,
-                                            fontWeight: isSelected ? '700' : '500'
-                                        }
-                                    ]}>
-                                        {option.label}
-                                    </Text>
+                                    <View style={styles.modalItemLabel}>
+                                        {option.color && (
+                                            <View style={[styles.colorPreview, { backgroundColor: option.color }]} />
+                                        )}
+                                        <Text style={[
+                                            styles.modalItemText,
+                                            {
+                                                color: isSelected ? colors.primary : colors.text,
+                                                fontWeight: isSelected ? '700' : '500'
+                                            }
+                                        ]}>
+                                            {option.label}
+                                        </Text>
+                                    </View>
                                     <MaterialIcons
                                         name={isSelected ? "check-circle" : "radio-button-unchecked"}
                                         size={24}
@@ -153,8 +159,18 @@ const styles = StyleSheet.create({
         borderRadius: 12,
         borderWidth: 1,
     },
+    modalItemLabel: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 10,
+    },
     modalItemText: {
         fontSize: 16,
+    },
+    colorPreview: {
+        width: 16,
+        height: 16,
+        borderRadius: 8,
     },
     closeButton: {
         borderRadius: 12,

--- a/src/components/UpdateAvailableModal.tsx
+++ b/src/components/UpdateAvailableModal.tsx
@@ -1,0 +1,234 @@
+import React, { useState, useEffect } from 'react';
+import {
+    Modal,
+    View,
+    Text,
+    TouchableOpacity,
+    StyleSheet,
+    Dimensions,
+    Animated,
+    TouchableWithoutFeedback,
+} from 'react-native';
+import { useTheme } from '@/theme';
+import { useTranslation } from '@/i18n';
+import { Ionicons } from '@expo/vector-icons';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+let updateListener: ((visible: boolean, version?: string) => void) | null = null;
+
+export const UpdateAvailableHelper = {
+    show: (version: string) => {
+        if (updateListener) {
+            updateListener(true, version);
+        }
+    },
+    hide: () => {
+        if (updateListener) {
+            updateListener(false);
+        }
+    }
+};
+
+interface UpdateAvailableModalProps {
+    onDownload?: () => void;
+}
+
+export const UpdateAvailableModal: React.FC<UpdateAvailableModalProps> = ({ onDownload }) => {
+    const [visible, setVisible] = useState(false);
+    const [version, setVersion] = useState('');
+    const { colors, typography, isDark } = useTheme();
+    const { t } = useTranslation();
+    const [slideAnim] = useState(new Animated.Value(0));
+    const insets = useSafeAreaInsets();
+
+    useEffect(() => {
+        updateListener = (vis, ver) => {
+            if (vis) {
+                setVersion(ver || '');
+                setVisible(true);
+                Animated.timing(slideAnim, {
+                    toValue: 1,
+                    duration: 300,
+                    useNativeDriver: true,
+                }).start();
+            } else {
+                Animated.timing(slideAnim, {
+                    toValue: 0,
+                    duration: 250,
+                    useNativeDriver: true,
+                }).start(() => {
+                    setVisible(false);
+                    setVersion('');
+                });
+            }
+        };
+        return () => {
+            updateListener = null;
+        };
+    }, [slideAnim]);
+
+    const handleClose = () => {
+        UpdateAvailableHelper.hide();
+    };
+
+    const handleDownload = () => {
+        UpdateAvailableHelper.hide();
+        setTimeout(() => {
+            onDownload?.();
+        }, 250);
+    };
+
+    if (!visible) return null;
+
+    const screenHeight = Dimensions.get('window').height;
+    const translateY = slideAnim.interpolate({
+        inputRange: [0, 1],
+        outputRange: [screenHeight, 0],
+    });
+
+    return (
+        <Modal visible={visible} transparent animationType="none" onRequestClose={handleClose}>
+            <View style={styles.overlay}>
+                <TouchableWithoutFeedback onPress={handleClose}>
+                    <Animated.View style={[
+                        styles.backdrop,
+                        { opacity: slideAnim, backgroundColor: isDark ? 'rgba(0, 0, 0, 0.75)' : 'rgba(0, 0, 0, 0.45)' }
+                    ]} />
+                </TouchableWithoutFeedback>
+
+                <Animated.View style={[
+                    styles.sheetContainer,
+                    {
+                        transform: [{ translateY }],
+                        backgroundColor: isDark ? 'rgba(28, 28, 30, 0.98)' : 'rgba(255, 255, 255, 0.98)',
+                        borderColor: colors.border,
+                        paddingBottom: Math.max(insets.bottom, 20) + 28,
+                        shadowColor: '#000',
+                        shadowOffset: { width: 0, height: -4 },
+                        shadowOpacity: 0.15,
+                        shadowRadius: 12,
+                        elevation: 24,
+                    }
+                ]}>
+                    <View style={[styles.dragHandle, { backgroundColor: isDark ? 'rgba(255, 255, 255, 0.15)' : 'rgba(0, 0, 0, 0.15)' }]} />
+
+                    <View style={[
+                        styles.iconContainer,
+                        {
+                            borderColor: colors.primary + '25',
+                            backgroundColor: isDark ? `${colors.primary}10` : `${colors.primary}05`,
+                            borderWidth: 1.5,
+                        }
+                    ]}>
+                        <Ionicons name="download-outline" size={32} color={colors.primary} />
+                    </View>
+
+                    <Text style={[typography.headline, styles.title, { color: colors.text }]}>
+                        {t('settings.updateAvailable')} {version ? `v${version}` : ''}
+                    </Text>
+
+                    <Text style={[typography.body, styles.description, { color: colors.textSecondary }]}>
+                        {t('alerts.newVersionAvailable')}
+                    </Text>
+
+                    <TouchableOpacity
+                        style={[
+                            styles.primaryButton,
+                            { borderRadius: 24, backgroundColor: colors.primary }
+                        ]}
+                        activeOpacity={0.8}
+                        onPress={handleDownload}
+                    >
+                        <Text style={styles.primaryButtonText}>
+                            {t('settings.downloadUpdate')}
+                        </Text>
+                    </TouchableOpacity>
+
+                    <TouchableOpacity
+                        style={styles.secondaryButton}
+                        activeOpacity={0.7}
+                        onPress={handleClose}
+                    >
+                        <Text style={[typography.body, styles.secondaryButtonText, { color: colors.textSecondary }]}>
+                            {t('ads.btnLater')}
+                        </Text>
+                    </TouchableOpacity>
+                </Animated.View>
+            </View>
+        </Modal>
+    );
+};
+
+const { width } = Dimensions.get('window');
+
+const styles = StyleSheet.create({
+    overlay: {
+        flex: 1,
+        justifyContent: 'flex-end',
+    },
+    backdrop: {
+        ...StyleSheet.absoluteFillObject,
+    },
+    sheetContainer: {
+        width: '100%',
+        maxWidth: width > 500 ? 460 : undefined,
+        alignSelf: 'center',
+        borderTopLeftRadius: 28,
+        borderTopRightRadius: 28,
+        borderWidth: 1,
+        borderBottomWidth: 0,
+        paddingHorizontal: 24,
+        paddingTop: 8,
+    },
+    dragHandle: {
+        width: 38,
+        height: 4,
+        borderRadius: 2,
+        alignSelf: 'center',
+        marginVertical: 12,
+    },
+    iconContainer: {
+        width: 64,
+        height: 64,
+        borderRadius: 32,
+        justifyContent: 'center',
+        alignItems: 'center',
+        alignSelf: 'center',
+        marginTop: 8,
+        marginBottom: 16,
+    },
+    title: {
+        textAlign: 'center',
+        fontWeight: 'bold',
+        marginBottom: 8,
+    },
+    description: {
+        textAlign: 'center',
+        paddingHorizontal: 12,
+        lineHeight: 20,
+        marginBottom: 24,
+    },
+    primaryButton: {
+        paddingVertical: 16,
+        alignItems: 'center',
+        justifyContent: 'center',
+        shadowOffset: { width: 0, height: 4 },
+        shadowOpacity: 0.2,
+        shadowRadius: 8,
+        elevation: 4,
+    },
+    primaryButtonText: {
+        color: '#ffffff',
+        fontSize: 16,
+        fontWeight: 'bold',
+    },
+    secondaryButton: {
+        paddingVertical: 14,
+        alignItems: 'center',
+        justifyContent: 'center',
+        marginTop: 4,
+    },
+    secondaryButtonText: {
+        fontWeight: '600',
+    },
+});

--- a/src/components/home/CollapsibleCard.tsx
+++ b/src/components/home/CollapsibleCard.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
 import {
     View,
     Text,
@@ -8,6 +8,7 @@ import {
     StyleProp,
     TextStyle,
 } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { MaterialIcons } from '@expo/vector-icons';
 import { useTheme } from '@/theme';
 import { Card } from '../Card';
@@ -18,6 +19,7 @@ interface CollapsibleCardProps {
     children: React.ReactNode;
     defaultExpanded?: boolean;
     onToggle?: (expanded: boolean) => void;
+    storageKey?: string;
     headerRight?: React.ReactNode;
     titleStyle?: StyleProp<TextStyle>;
 }
@@ -31,18 +33,30 @@ export function CollapsibleCard({
     children,
     defaultExpanded = true,
     onToggle,
+    storageKey,
     headerRight,
     titleStyle,
 }: CollapsibleCardProps) {
     const { colors, typography, spacing } = useTheme();
     const [isExpanded, setIsExpanded] = useState(defaultExpanded);
 
+    useEffect(() => {
+        if (!storageKey) return;
+
+        AsyncStorage.getItem(storageKey)
+            .then((value) => {
+                if (value !== null) setIsExpanded(value === 'true');
+            })
+            .catch(() => {});
+    }, [storageKey]);
+
     const toggleExpand = useCallback(() => {
         LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
         const newState = !isExpanded;
         setIsExpanded(newState);
+        if (storageKey) AsyncStorage.setItem(storageKey, String(newState)).catch(() => {});
         onToggle?.(newState);
-    }, [isExpanded, onToggle]);
+    }, [isExpanded, onToggle, storageKey]);
 
     return (
         <Card style={{ marginBottom: spacing.md }}>

--- a/src/components/home/ConnectionStatusCard.tsx
+++ b/src/components/home/ConnectionStatusCard.tsx
@@ -166,6 +166,7 @@ export function ConnectionStatusCard({
     return (
         <CollapsibleCard
             title={t('home.connectionStatus')}
+            storageKey="home.connectionStatus.expanded"
             headerRight={headerRightBadge}
         >
             <View style={styles.topRow}>

--- a/src/components/home/QuickActionsCard.tsx
+++ b/src/components/home/QuickActionsCard.tsx
@@ -88,6 +88,7 @@ interface QuickActionsCardProps {
     return (
         <CollapsibleCard
             title={t('home.actions')}
+            storageKey="home.quickActions.expanded"
             headerRight={headerRightBadge}
         >
             {/* Top row - Large actions */}

--- a/src/components/home/SignalInfoCard.tsx
+++ b/src/components/home/SignalInfoCard.tsx
@@ -182,6 +182,7 @@ export function SignalInfoCard({ t, signalInfo, modemStatus }: SignalInfoCardPro
     return (
         <CollapsibleCard
             title={t('home.signalInfo')}
+            storageKey="home.signalInfo.expanded"
             headerRight={headerRightBadge}
         >
             <View style={styles.gridContainer}>

--- a/src/components/home/TrafficStatsCard.tsx
+++ b/src/components/home/TrafficStatsCard.tsx
@@ -137,9 +137,7 @@ export function TrafficStatsCard({
                 </>
             )}
 
-            <View style={{ height: 1, backgroundColor: colors.border, marginVertical: spacing.md }} />
-
-            <View style={{ flexDirection: 'row', justifyContent: 'center', marginTop: spacing.md }}>
+            <View style={{ flexDirection: 'row', justifyContent: 'center' }}>
                 <TouchableOpacity
                     style={{
                         flex: 1,

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -21,4 +21,5 @@ export * from './SignalPointingModal';
 export * from './AdBanner';
 export * from './AdBlockAlertModal';
 export * from './ChangelogModal';
+export * from './UpdateAvailableModal';
 export * from './SignalBubble';

--- a/src/components/settings/ReleaseNotesModal.tsx
+++ b/src/components/settings/ReleaseNotesModal.tsx
@@ -1,8 +1,19 @@
 import React from 'react';
-import { View, Text, ScrollView } from 'react-native';
+import {
+    View,
+    Text,
+    ScrollView,
+    Modal,
+    TouchableOpacity,
+    StyleSheet,
+    StatusBar,
+    Platform,
+    Linking,
+} from 'react-native';
 import { useTheme } from '@/theme';
 import { useTranslation } from '@/i18n';
-import { PageSheetModal } from '../PageSheetModal';
+import { BlurView } from 'expo-blur';
+import { ModalBackground } from '../ModalBackground';
 
 interface ReleaseNotesModalProps {
     visible: boolean;
@@ -49,18 +60,82 @@ function extractChangelog(body: string): string {
     return body.trim();
 }
 
-function renderInlineFormatting(text: string, colors: any) {
-    const parts = text.split('**');
-    if (parts.length <= 1) return <Text>{text}</Text>;
+// Inline markdown: **bold**, *italic*, `code`, [label](url), bare URL
+function renderInline(text: string, colors: any, typography: any, keyPrefix: string): React.ReactNode[] {
+    const regex =
+        /(\*\*[^*]+\*\*|\*[^*]+\*|`[^`]+`|\[[^\]]+\]\([^)]+\)|https?:\/\/[^\s)]+)/g;
+    const nodes: React.ReactNode[] = [];
+    let lastIndex = 0;
+    let match: RegExpExecArray | null;
+    let i = 0;
 
-    return parts.map((part, index) => {
-        const isBold = index % 2 === 1;
-        return (
-            <Text key={index} style={isBold ? { fontWeight: '700', color: colors.text } : undefined}>
-                {part}
+    while ((match = regex.exec(text)) !== null) {
+        if (match.index > lastIndex) {
+            nodes.push(
+                <Text key={`${keyPrefix}-t${i}`} style={{ color: colors.text }}>
+                    {text.slice(lastIndex, match.index)}
+                </Text>
+            );
+            i++;
+        }
+
+        const token = match[0];
+        if (token.startsWith('**')) {
+            nodes.push(
+                <Text key={`${keyPrefix}-b${i}`} style={{ fontWeight: '700', color: colors.text }}>
+                    {token.slice(2, -2)}
+                </Text>
+            );
+        } else if (token.startsWith('`')) {
+            nodes.push(
+                <Text key={`${keyPrefix}-c${i}`} style={[typography.body, { color: colors.primary, fontFamily: Platform.OS === 'ios' ? 'Menlo' : 'monospace' }]}>
+                    {token.slice(1, -1)}
+                </Text>
+            );
+        } else if (token.startsWith('*')) {
+            nodes.push(
+                <Text key={`${keyPrefix}-i${i}`} style={{ fontStyle: 'italic', color: colors.text }}>
+                    {token.slice(1, -1)}
+                </Text>
+            );
+        } else if (token.startsWith('[')) {
+            const linkMatch = token.match(/^\[([^\]]+)\]\(([^)]+)\)$/);
+            if (linkMatch) {
+                nodes.push(
+                    <Text
+                        key={`${keyPrefix}-l${i}`}
+                        style={{ color: colors.primary, textDecorationLine: 'underline' }}
+                        onPress={() => Linking.openURL(linkMatch[2])}
+                    >
+                        {linkMatch[1]}
+                    </Text>
+                );
+            }
+        } else {
+            nodes.push(
+                <Text
+                    key={`${keyPrefix}-u${i}`}
+                    style={{ color: colors.primary, textDecorationLine: 'underline' }}
+                    onPress={() => Linking.openURL(token)}
+                >
+                    {token}
+                </Text>
+            );
+        }
+
+        i++;
+        lastIndex = regex.lastIndex;
+    }
+
+    if (lastIndex < text.length) {
+        nodes.push(
+            <Text key={`${keyPrefix}-t${i}`} style={{ color: colors.text }}>
+                {text.slice(lastIndex)}
             </Text>
         );
-    });
+    }
+
+    return nodes;
 }
 
 function renderMarkdown(text: string, colors: any, typography: any) {
@@ -92,18 +167,33 @@ function renderMarkdown(text: string, colors: any, typography: any) {
                         }
                     ]}
                 >
-                    {headerText}
+                    {renderInline(headerText, colors, typography, `h${index}`)}
                 </Text>
             );
         }
 
-        if (trimmed.startsWith('-') || trimmed.startsWith('*')) {
+        if (/^[-*]\s+/.test(trimmed)) {
             const itemText = trimmed.replace(/^[-*]\s*/, '');
             return (
                 <View key={index} style={{ flexDirection: 'row', alignItems: 'flex-start', marginVertical: 3, paddingLeft: 8 }}>
                     <Text style={[typography.body, { color: colors.primary, marginRight: 6 }]}>•</Text>
                     <Text style={[typography.body, { color: colors.text, flex: 1, lineHeight: 22 }]}>
-                        {renderInlineFormatting(itemText, colors)}
+                        {renderInline(itemText, colors, typography, `u${index}`)}
+                    </Text>
+                </View>
+            );
+        }
+
+        const orderedMatch = trimmed.match(/^(\d+)\.\s+(.*)/);
+        if (orderedMatch) {
+            const itemText = orderedMatch[2];
+            return (
+                <View key={index} style={{ flexDirection: 'row', alignItems: 'flex-start', marginVertical: 3, paddingLeft: 8 }}>
+                    <Text style={[typography.body, { color: colors.primary, marginRight: 6, fontWeight: '600' }]}>
+                        {orderedMatch[1]}.
+                    </Text>
+                    <Text style={[typography.body, { color: colors.text, flex: 1, lineHeight: 22 }]}>
+                        {renderInline(itemText, colors, typography, `o${index}`)}
                     </Text>
                 </View>
             );
@@ -111,7 +201,7 @@ function renderMarkdown(text: string, colors: any, typography: any) {
 
         return (
             <Text key={index} style={[typography.body, { color: colors.text, marginVertical: 4, lineHeight: 22 }]}>
-                {renderInlineFormatting(trimmed, colors)}
+                {renderInline(trimmed, colors, typography, `p${index}`)}
             </Text>
         );
     });
@@ -122,28 +212,71 @@ export function ReleaseNotesModal({
     onClose,
     selectedNotes,
 }: ReleaseNotesModalProps) {
-    const { colors, typography } = useTheme();
+    const { colors, typography, isDark } = useTheme();
     const { t } = useTranslation();
 
     return (
-        <PageSheetModal
+        <Modal
             visible={visible}
-            onClose={onClose}
-            title={t('settings.releaseNotes') || 'Release Notes'}
-            cancelText={t('common.done') || 'Done'}
+            animationType="slide"
+            presentationStyle="overFullScreen"
+            transparent
+            onRequestClose={onClose}
         >
-            {selectedNotes && (
-                <ScrollView
-                    style={{ flex: 1 }}
-                    contentContainerStyle={{ padding: 20, paddingBottom: 60 }}
-                >
-                    <Text style={[typography.subheadline, { color: colors.textSecondary, marginBottom: 12 }]}>
-                        {t('settings.version') || 'Version'} {selectedNotes.version}
+            <BlurView
+                intensity={18}
+                tint={isDark ? 'dark' : 'light'}
+                experimentalBlurMethod="dimezisBlurView"
+                style={[
+                    styles.container,
+                    {
+                        backgroundColor: isDark
+                            ? 'rgba(10, 10, 10, 0.82)'
+                            : 'rgba(255, 255, 255, 0.82)',
+                    }
+                ]}
+            >
+                <ModalBackground />
+                <View style={[styles.header, {
+                    borderBottomColor: colors.border,
+                    paddingTop: Platform.OS === 'android' ? (StatusBar.currentHeight || 24) + 16 : 16
+                }]}>
+                    <TouchableOpacity onPress={onClose}>
+                        <Text style={[typography.body, { color: colors.primary }]}>
+                            {t('common.done') || 'Done'}
+                        </Text>
+                    </TouchableOpacity>
+                    <Text style={[typography.headline, { color: colors.text, flex: 1, textAlign: 'center' }]} numberOfLines={1}>
+                        {t('settings.releaseNotes') || 'Release Notes'}
                     </Text>
-                    <View style={{ height: 1, backgroundColor: colors.border, marginBottom: 16 }} />
-                    {renderMarkdown(extractChangelog(selectedNotes.notes), colors, typography)}
-                </ScrollView>
-            )}
-        </PageSheetModal>
+                    <View style={{ width: 50 }} />
+                </View>
+                {selectedNotes && (
+                    <ScrollView
+                        style={{ flex: 1 }}
+                        contentContainerStyle={{ padding: 20, paddingBottom: 60 }}
+                    >
+                        <Text style={[typography.subheadline, { color: colors.textSecondary, marginBottom: 12 }]}>
+                            {t('settings.version') || 'Version'} {selectedNotes.version}
+                        </Text>
+                        <View style={{ height: 1, backgroundColor: colors.border, marginBottom: 16 }} />
+                        {renderMarkdown(extractChangelog(selectedNotes.notes), colors, typography)}
+                    </ScrollView>
+                )}
+            </BlurView>
+        </Modal>
     );
 }
+
+const styles = StyleSheet.create({
+    container: {
+        flex: 1,
+    },
+    header: {
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        padding: 16,
+        borderBottomWidth: 1,
+    },
+});

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1,4 +1,10 @@
 {
+  "changelog": {
+    "title": "Successfully Updated!",
+    "giveStar": "Give Star",
+    "fullChangelog": "Full Changelog",
+    "continue": "Continue"
+  },
   "ads": {
     "adblockNoticeMessage": "Please make sure you are not using an ad blocker to enjoy all the features of this app.",
     "adblockNoticeTitle": "AdBlock Notice",
@@ -127,9 +133,9 @@
     "changingIp": "Changing IP...",
     "checkFailed": "Check failed. Please try again.",
     "checkLogin": "Please check if you're logged in to the modem",
-    "clearHistory": "Clear History",
-    "clearHistoryConfirm": "Are you sure you want to clear all traffic history? This action cannot be undone.",
-    "clearHistoryFailed": "Failed to clear traffic history",
+    "clearHistory": "Clear Usage History",
+    "clearHistoryConfirm": "Are you sure you want to clear all usage history? This action cannot be undone.",
+    "clearHistoryFailed": "Failed to clear usage history",
     "confirmDisableData": "Are you sure you want to disable mobile data?",
     "confirmEnableData": "Are you sure you want to enable mobile data?",
     "connected": "Connected",

--- a/src/i18n/id.json
+++ b/src/i18n/id.json
@@ -1,4 +1,10 @@
 {
+  "changelog": {
+    "title": "Berhasil Diperbarui!",
+    "giveStar": "Beri Bintang",
+    "fullChangelog": "Lihat Changelog Lengkap",
+    "continue": "Lanjutkan"
+  },
   "ads": {
     "adblockNoticeMessage": "Pastikan Anda tidak menggunakan adblock untuk dapat menggunakan semua fitur dalam aplikasi ini secara maksimal.",
     "adblockNoticeTitle": "Pemberitahuan AdBlock",
@@ -127,7 +133,7 @@
     "changingIp": "Mengganti IP...",
     "checkFailed": "Pemeriksaan gagal. Silakan coba lagi.",
     "checkLogin": "Periksa apakah Anda sudah login ke modem",
-    "clearHistory": "Hapus Riwayat",
+    "clearHistory": "Hapus Riwayat Penggunaan",
     "clearHistoryConfirm": "Apakah Anda yakin ingin menghapus semua riwayat penggunaan? Tindakan ini tidak dapat dibatalkan.",
     "clearHistoryFailed": "Gagal menghapus riwayat penggunaan",
     "confirmDisableData": "Yakin ingin menonaktifkan data seluler?",


### PR DESCRIPTION
- Add generic webview screen for browsing GitHub links inside the app
- Replace native update alert with custom bottom-sheet UpdateAvailableModal
- Redesign ReleaseNotesModal using glassmorphism BlurView
- Persist CollapsibleCard expand/collapse states in AsyncStorage
- Support color preview circles in SelectionModal options
- Bump app version to 1.1.65