### PR TITLE
feat(ui): add lazy rendering, cancel confirmation, download fixes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 - **Expanded Quick Actions** Added more shortcut buttons to Quick Actions, making common modem and network controls faster to access from the home dashboard.
 - **Redesigned SpeedTest Modal** Complete visual upgrade of SpeedTest modal with new layout elements and improved user experience.
 - **Settings Update Improvements** Improved the Settings > Update flow for a clearer update-checking experience, better release information display, and smoother navigation.
+- **Unified Modal Design System** Introduced consistent design across all modals: shared ModalHeader for uniform title/close button, ModalButton with primary/secondary/danger/outline variants, and glassmorphism card layout for settings modals. Applied to MonthlySettings, Parental Profile, Band Selection, Device Detail, APN, Profile Edit, Changelog, and Update modals.
 - **GitHub WebView** Added a WebView screen for browsing GitHub links inside the app.
 - **Minor Bug Fixes** Fixed several minor bugs across the app for improved stability and a smoother experience.
 
@@ -27,6 +28,7 @@
 - **Penambahan Tombol Quick Actions** Menambahkan lebih banyak tombol pintasan pada Quick Actions agar kontrol modem dan jaringan yang sering digunakan bisa diakses lebih cepat dari dashboard utama.
 - **SpeedTest Modal Redesign** Desain ulang SpeedTest modal dengan layout yang lebih baik dan user experience yang lebih baik.
 - **Perbaikan Settings > Update** Menyempurnakan alur Settings > Update agar proses pengecekan pembaruan lebih jelas, informasi rilis lebih mudah dibaca, dan navigasi terasa lebih lancar.
+- **Sistem Desain Modal Konsisten** Perancangan ulang seluruh modal dengan desain yang konsisten: ModalHeader bersama untuk judul/tombol close yang seragam, ModalButton dengan varian primary/secondary/danger/outline, dan tata letak kartu glassmorphism untuk modal pengaturan. Diterapkan pada modal MonthlySettings, Profil Parental, Pemilihan Band, Detail Perangkat, APN, Edit Profil, Changelog, dan Pembaruan.
 - **WebView GitHub** Menambahkan layar WebView untuk membuka halaman GitHub di dalam aplikasi.
 - **Perbaikan Bug Minor** Memperbaiki beberapa bug minor di berbagai bagian aplikasi untuk meningkatkan stabilitas dan pengalaman yang lebih lancar.
 

--- a/src/app/(tabs)/home.tsx
+++ b/src/app/(tabs)/home.tsx
@@ -12,7 +12,7 @@ import { useRouter } from 'expo-router';
 import { MaterialIcons } from '@expo/vector-icons';
 import { useTheme } from '@/theme';
 import { Card, ThemedAlertHelper, WebViewLogin, BandSelectionModal, MonthlySettingsModal, MeshGradientBackground, AnimatedScreen, BouncingDots, RefreshIndicator, SignalPointingModal, AdBanner, AdNative } from '@/components';
-import { QuickActionsCard, ConnectionStatusCard, SignalInfoCard, TrafficStatsCard, ConnectionStatusSkeleton, QuickActionsSkeleton, TrafficStatsSkeleton, homeStyles as styles, DiagnosisResultModal, SpeedTestModal, NoSignalModal } from '@/components/home';
+import { QuickActionsCard, ConnectionStatusCard, SignalInfoCard, TrafficStatsCard, ConnectionStatusSkeleton, QuickActionsSkeleton, TrafficStatsSkeleton, SignalInfoSkeleton, homeStyles as styles, DiagnosisResultModal, SpeedTestModal, NoSignalModal } from '@/components/home';
 import { useAuthStore } from '@/stores/auth.store';
 import { useModemStore } from '@/stores/modem.store';
 import { useThemeStore } from '@/stores/theme.store';
@@ -186,6 +186,9 @@ export default function HomeScreen() {
             wanInfo={wanInfo}
             trafficStats={trafficStats}
             selectedBands={homeData.selectedBands}
+            lazy
+            loading={!hasValidData}
+            skeleton={<ConnectionStatusSkeleton />}
           />
 
           <AdNative />
@@ -194,6 +197,9 @@ export default function HomeScreen() {
             t={t}
             signalInfo={signalInfo}
             modemStatus={modemStatus}
+            lazy
+            loading={!hasValidData}
+            skeleton={<SignalInfoSkeleton />}
           />
 
           {trafficStats && (

--- a/src/app/(tabs)/settings/update.tsx
+++ b/src/app/(tabs)/settings/update.tsx
@@ -1,6 +1,6 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, ScrollView } from 'react-native';
-import { Stack } from 'expo-router';
+import { Stack, useLocalSearchParams } from 'expo-router';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import Animated from 'react-native-reanimated';
 import { useTheme } from '@/theme';
@@ -22,6 +22,15 @@ export default function UpdateScreen() {
     const { downloading, downloadProgress, handleDownloadAndInstall, handleCancelDownload } = useUpdateDownload({ t });
 
     const [selectedNotes, setSelectedNotes] = useState<{ version: string; notes: string } | null>(null);
+    const { autoDownload } = useLocalSearchParams<{ autoDownload?: string }>();
+    const autoDownloadTriggered = useRef(false);
+
+    useEffect(() => {
+        if (autoDownload === 'true' && releaseInfo?.downloadUrl && !downloading && !autoDownloadTriggered.current) {
+            autoDownloadTriggered.current = true;
+            handleDownloadAndInstall(releaseInfo.downloadUrl, releaseInfo.version);
+        }
+    }, [autoDownload, releaseInfo, downloading]);
 
     return (
         <AnimatedScreen noAnimation>

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -481,7 +481,7 @@ export default function RootLayout() {
                 />
 
                 <AdBlockAlertModal />
-                <UpdateAvailableModal onDownload={() => router.push('/settings/update')} />
+                <UpdateAvailableModal onDownload={() => router.push('/settings/update?autoDownload=true')} />
 <ChangelogModal />
                 {isAuthenticated && signalBubbleEnabled && <SignalBubble />}
             </KeyboardProvider>

--- a/src/components/AdBlockAlertModal.tsx
+++ b/src/components/AdBlockAlertModal.tsx
@@ -220,7 +220,7 @@ export const AdBlockAlertModal: React.FC<AdBlockAlertModalProps> = () => {
                         title={t('ads.btnIHaveDisabled')}
                         variant="danger"
                         onPress={handleClose}
-                        style={{ borderRadius: 24, marginTop: 12 }}
+                        style={{ borderRadius: 14, marginTop: 12 }}
                     />
 
                     <ModalButton

--- a/src/components/UpdateAvailableModal.tsx
+++ b/src/components/UpdateAvailableModal.tsx
@@ -148,7 +148,7 @@ export const UpdateAvailableModal: React.FC<UpdateAvailableModalProps> = ({ onDo
                         title={t('settings.downloadUpdate')}
                         variant="primary"
                         onPress={handleDownload}
-                        style={{ borderRadius: 24 }}
+                        style={{ borderRadius: 14 }}
                     />
 
                     <ModalButton

--- a/src/components/home/CollapsibleCard.tsx
+++ b/src/components/home/CollapsibleCard.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useEffect } from 'react';
+import React, { useState, useCallback, useEffect, useRef } from 'react';
 import {
     View,
     Text,
@@ -19,26 +19,36 @@ interface CollapsibleCardProps {
     children: React.ReactNode;
     defaultExpanded?: boolean;
     onToggle?: (expanded: boolean) => void;
+    onExpanded?: () => void;
     storageKey?: string;
     headerRight?: React.ReactNode;
     titleStyle?: StyleProp<TextStyle>;
+    lazy?: boolean;
+    loading?: boolean;
+    skeleton?: React.ReactNode;
 }
 
 /**
  * A card component that can be collapsed/expanded.
  * Shows only the title when collapsed, full content when expanded.
+ * With lazy={true}, children only render when expanded and loading is handled.
  */
 export function CollapsibleCard({
     title,
     children,
     defaultExpanded = true,
     onToggle,
+    onExpanded,
     storageKey,
     headerRight,
     titleStyle,
+    lazy = false,
+    loading = false,
+    skeleton,
 }: CollapsibleCardProps) {
     const { colors, typography, spacing } = useTheme();
     const [isExpanded, setIsExpanded] = useState<boolean | null>(null);
+    const hasBeenExpanded = useRef(false);
 
     useEffect(() => {
         if (!storageKey) {
@@ -47,7 +57,12 @@ export function CollapsibleCard({
         }
         AsyncStorage.getItem(storageKey)
             .then((value) => {
-                setIsExpanded(value !== null ? value === 'true' : defaultExpanded);
+                const expanded = value !== null ? value === 'true' : defaultExpanded;
+                setIsExpanded(expanded);
+                if (expanded && lazy && !hasBeenExpanded.current) {
+                    hasBeenExpanded.current = true;
+                    onExpanded?.();
+                }
             })
             .catch(() => setIsExpanded(defaultExpanded));
     }, [storageKey, defaultExpanded]);
@@ -58,7 +73,14 @@ export function CollapsibleCard({
         setIsExpanded(newState);
         if (storageKey) AsyncStorage.setItem(storageKey, String(newState)).catch(() => {});
         onToggle?.(newState);
-    }, [isExpanded, onToggle, storageKey]);
+        if (newState && lazy) {
+            hasBeenExpanded.current = true;
+            onExpanded?.();
+        }
+    }, [isExpanded, onToggle, storageKey, lazy, onExpanded]);
+
+    const showContent = isExpanded === true && (!lazy || hasBeenExpanded.current);
+    const showSkeleton = showContent && lazy && loading && skeleton;
 
     return (
         <Card style={{ marginBottom: spacing.md }}>
@@ -91,7 +113,7 @@ export function CollapsibleCard({
                 <>
                     <View style={[styles.divider, { backgroundColor: colors.border }]} />
                     <View style={styles.content}>
-                        {children}
+                        {showSkeleton ? skeleton : children}
                     </View>
                 </>
             )}

--- a/src/components/home/ConnectionStatusCard.tsx
+++ b/src/components/home/ConnectionStatusCard.tsx
@@ -52,6 +52,9 @@ interface ConnectionStatusCardProps {
         currentUploadRate?: number;
     };
     selectedBands?: string[];
+    lazy?: boolean;
+    loading?: boolean;
+    skeleton?: React.ReactNode;
 }
 
 /**
@@ -65,6 +68,9 @@ export function ConnectionStatusCard({
     wanInfo,
     trafficStats,
     selectedBands,
+    lazy,
+    loading,
+    skeleton,
 }: ConnectionStatusCardProps) {
     const { colors, typography, isDark } = useTheme();
 
@@ -168,6 +174,9 @@ export function ConnectionStatusCard({
             title={t('home.connectionStatus')}
             storageKey="home.connectionStatus.expanded"
             headerRight={headerRightBadge}
+            lazy={lazy}
+            loading={loading}
+            skeleton={skeleton}
         >
             <View style={styles.topRow}>
                 <View style={styles.providerSection}>

--- a/src/components/home/HomeSkeleton.tsx
+++ b/src/components/home/HomeSkeleton.tsx
@@ -178,4 +178,42 @@ const styles = StyleSheet.create({
         flexDirection: 'row',
         alignItems: 'center',
     },
+    signalGrid: {
+        flexDirection: 'row',
+        flexWrap: 'wrap',
+        justifyContent: 'space-between',
+    },
+    signalItem: {
+        width: '48.5%',
+        padding: 14,
+        borderRadius: 12,
+        marginBottom: 10,
+    },
 });
+
+/**
+ * Skeleton for Signal Info card
+ */
+export function SignalInfoSkeleton() {
+    const { glassmorphism, isDark } = useTheme();
+
+    return (
+        <View style={[styles.card, {
+            backgroundColor: isDark ? glassmorphism.background.dark.card : glassmorphism.background.light.card,
+            borderColor: isDark ? glassmorphism.border.dark : glassmorphism.border.light,
+        }]}>
+            <Skeleton width="40%" height={20} style={{ marginBottom: 14 }} />
+            <View style={styles.signalGrid}>
+                {[1, 2, 3, 4].map((i) => (
+                    <View key={i} style={[styles.signalItem, {
+                        backgroundColor: isDark ? 'rgba(255,255,255,0.03)' : 'rgba(0,0,0,0.02)',
+                    }]}>
+                        <Skeleton width="60%" height={10} style={{ marginBottom: 6 }} />
+                        <Skeleton width="50%" height={18} style={{ marginBottom: 4 }} />
+                        <Skeleton width="100%" height={8} borderRadius={4} />
+                    </View>
+                ))}
+            </View>
+        </View>
+    );
+}

--- a/src/components/home/SignalInfoCard.tsx
+++ b/src/components/home/SignalInfoCard.tsx
@@ -21,6 +21,9 @@ interface SignalInfoCardProps {
     modemStatus?: {
         signalIcon?: string | number;
     };
+    lazy?: boolean;
+    loading?: boolean;
+    skeleton?: React.ReactNode;
 }
 
 const getSignalQuality = (
@@ -42,14 +45,19 @@ const getSignalQuality = (
     }
 };
 
-export function SignalInfoCard({ t, signalInfo, modemStatus }: SignalInfoCardProps) {
+export function SignalInfoCard({ t, signalInfo, modemStatus, lazy, loading, skeleton }: SignalInfoCardProps) {
     const { colors, typography, spacing, isDark } = useTheme();
 
     const hasSignalData = (signalInfo && (signalInfo.rssi || signalInfo.rsrp)) || modemStatus?.signalIcon;
 
     if (!hasSignalData) {
         return (
-            <CollapsibleCard title={t('home.signalInfo')}>
+            <CollapsibleCard
+                title={t('home.signalInfo')}
+                lazy={lazy}
+                loading={loading}
+                skeleton={skeleton}
+            >
                 <Text style={[typography.body, { color: colors.textSecondary, textAlign: 'center', padding: spacing.lg }]}>
                     {t('home.noSignalAvailable')}{'\n'}
                     {t('home.checkLogin')}
@@ -184,6 +192,9 @@ export function SignalInfoCard({ t, signalInfo, modemStatus }: SignalInfoCardPro
             title={t('home.signalInfo')}
             storageKey="home.signalInfo.expanded"
             headerRight={headerRightBadge}
+            lazy={lazy}
+            loading={loading}
+            skeleton={skeleton}
         >
             <View style={styles.gridContainer}>
                 {metrics.map((metric, index) => {

--- a/src/hooks/settings/useUpdateDownload.ts
+++ b/src/hooks/settings/useUpdateDownload.ts
@@ -52,6 +52,15 @@ export function useUpdateDownload({ t }: UseUpdateDownloadProps) {
             setDownloadResumable(resumable);
 
             const result = await resumable.downloadAsync();
+
+            if (isCancelledRef.current) {
+                isCancelledRef.current = false;
+                setDownloading(false);
+                setDownloadProgress(0);
+                setDownloadResumable(null);
+                return;
+            }
+
             setDownloading(false);
             setDownloadResumable(null);
 
@@ -83,12 +92,22 @@ export function useUpdateDownload({ t }: UseUpdateDownloadProps) {
                         ]
                     );
                 }
-            } else {
-                throw new Error('Download failed: result is empty');
+            } else if (!isCancelledRef.current) {
+                ThemedAlertHelper.alert(
+                    t('common.error') || 'Error',
+                    t('settings.downloadFailed') || 'Failed to download or install update. Please try again or download manually.',
+                    [
+                        { text: t('common.ok') || 'OK', style: 'cancel' },
+                        { text: t('settings.downloadUpdate') || 'Open Browser', onPress: () => Linking.openURL(url) }
+                    ]
+                );
             }
         } catch (err: any) {
             if (isCancelledRef.current) {
                 isCancelledRef.current = false;
+                setDownloading(false);
+                setDownloadProgress(0);
+                setDownloadResumable(null);
                 return;
             }
             console.error('Download/Install failed:', err);
@@ -109,27 +128,28 @@ export function useUpdateDownload({ t }: UseUpdateDownloadProps) {
 
     const handleCancelDownload = async () => {
         if (downloadResumable) {
-            try {
-                isCancelledRef.current = true;
-                await downloadResumable.cancelAsync();
-                setDownloading(false);
-                setDownloadProgress(0);
-                setDownloadResumable(null);
-                ThemedAlertHelper.alert(
-                    t('settings.downloadCancelledTitle') || 'Cancelled',
-                    t('settings.downloadCancelledMessage') || 'Download cancelled.',
-                    [{ text: t('common.ok') || 'OK', style: 'default' }]
-                );
-            } catch (e) {
-                console.error('Error cancelling download:', e);
-                isCancelledRef.current = false;
-                const message = e instanceof Error ? e.message : String(e);
-                ThemedAlertHelper.alert(
-                    t('common.error') || 'Error',
-                    `${t('settings.downloadFailed') || 'Failed to download or install update. Please try again or download manually.'}\n\n${message}`,
-                    [{ text: t('common.ok') || 'OK', style: 'default' }]
-                );
-            }
+            ThemedAlertHelper.alert(
+                t('common.confirm') || 'Confirm',
+                t('settings.downloadCancelledConfirm') || 'Are you sure you want to cancel the download?',
+                [
+                    { text: t('common.no') || 'No', style: 'destructive' },
+                    {
+                        text: t('common.yes') || 'Yes',
+                        style: 'cancel',
+                        onPress: async () => {
+                            isCancelledRef.current = true;
+                            try {
+                                await downloadResumable.cancelAsync();
+                            } catch (e) {
+                                // cancelAsync may throw if download already finished — ignore
+                            }
+                            setDownloading(false);
+                            setDownloadProgress(0);
+                            setDownloadResumable(null);
+                        }
+                    }
+                ]
+            );
         }
     };
 

--- a/src/hooks/wifi/useParentalControls.ts
+++ b/src/hooks/wifi/useParentalControls.ts
@@ -55,6 +55,10 @@ export function useParentalControls({
 
   const handleToggleParentalControl = async (enabled: boolean) => {
     if (!wifiService || isTogglingParental) return;
+    if (enabled && parentalProfiles.length === 0) {
+      ThemedAlertHelper.alert(t('common.error'), t('parentalControl.noProfiles'));
+      return;
+    }
     setIsTogglingParental(true);
     try {
       await wifiService.toggleParentalControl(enabled);

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -524,6 +524,7 @@
     "disableDebugConfirm": "Disable Debug Mode?",
     "disableDebugMessage": "Disabling debug mode will delete all recorded API logs. This action cannot be undone.",
     "downloadCancelledMessage": "Download cancelled.",
+    "downloadCancelledConfirm": "Are you sure you want to cancel the download?",
     "downloadCancelledTitle": "Cancelled",
     "downloadComplete": "Update downloaded successfully. Please open and install the APK file manually, or open the link in your browser.",
     "downloadDebugLog": "Download Debug Log",

--- a/src/i18n/id.json
+++ b/src/i18n/id.json
@@ -524,6 +524,7 @@
     "disableDebugConfirm": "Nonaktifkan Mode Debug?",
     "disableDebugMessage": "Menonaktifkan mode debug akan menghapus semua log API yang tercatat. Tindakan ini tidak dapat dibatalkan.",
     "downloadCancelledMessage": "Unduhan dibatalkan.",
+    "downloadCancelledconfirm": "Apakah Anda yakin ingin membatalkan unduhan?",
     "downloadCancelledTitle": "Dibatalkan",
     "downloadComplete": "Pembaruan berhasil diunduh. Silakan buka dan instal file APK secara manual, atau buka tautan di browser Anda.",
     "downloadDebugLog": "Unduh Log Debug",


### PR DESCRIPTION
- CollapsibleCard: add lazy/loading/skeleton props, defer children until expanded to reduce render work
- useUpdateDownload: fix race condition on cancel where flag checked after throw; replace throw with alert on empty result; add confirmation dialog before cancelling download
- home cards: lazy render ConnectionStatusCard and SignalInfoCard with skeleton placeholders
- parental control: block toggle when no profiles exist
- update page: auto-download via ?autoDownload param (once)
- changelog: add unified modal design system entry for v1.1.65