### PR TITLE
fix: login retry, modal text centering, gate changelog/adblock behind auth

### DIFF
--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -193,6 +193,9 @@ export default function RootLayout() {
 
     const checkAndShowChangelog = async () => {
         try {
+            // Only show changelog after user is authenticated — never on login page
+            if (!useAuthStore.getState().isAuthenticated) return;
+
             const currentVersion = Constants.expoConfig?.version || '1.1.55';
             const shownVersion = await AsyncStorage.getItem(CHANGELOG_SHOWN_VERSION_KEY);
 

--- a/src/components/AdBanner.tsx
+++ b/src/components/AdBanner.tsx
@@ -12,6 +12,7 @@ import { MaterialIcons } from '@expo/vector-icons';
 import { useTheme } from '@/theme';
 import { useTranslation } from '@/i18n';
 import { AdBlockAlertHelper } from './AdBlockAlertModal';
+import { useAuthStore } from '@/stores/auth.store';
 import {
     initAdMob,
     isAdMobInitialized,
@@ -24,6 +25,8 @@ import {
 
 function triggerAdblockAlert(error: any) {
     if (!error) return;
+    // Only surface adblock prompt when user is authenticated — never on login page
+    if (!useAuthStore.getState().isAuthenticated) return;
     const errMsg = error?.message || String(error);
     if (errMsg.includes('doubleclick') || errMsg.includes('ad server') || errMsg.includes('Failed to connect') || errMsg.includes('Timeout')) {
         AdBlockAlertHelper.show();

--- a/src/components/ModalButton.tsx
+++ b/src/components/ModalButton.tsx
@@ -64,7 +64,12 @@ export function ModalButton({
             ) : (
                 <Text style={[
                     typography.headline,
-                    { color: getTextColor(), fontWeight: variant === 'secondary' ? '600' : 'bold' },
+                    {
+                        color: getTextColor(),
+                        fontWeight: variant === 'secondary' ? '600' : 'bold',
+                        textAlign: 'center',
+                    },
+                    styles.text,
                 ]}>
                     {title}
                 </Text>
@@ -78,5 +83,9 @@ const styles = StyleSheet.create({
         height: 52,
         alignItems: 'center',
         justifyContent: 'center',
+    },
+    text: {
+        flexShrink: 1,
+        textAlign: 'center',
     },
 });

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -169,8 +169,8 @@ export const ToastContainer: React.FC<ToastContainerProps> = ({ config, onDismis
 const styles = StyleSheet.create({
     toastWrapper: {
         position: 'absolute',
-        left: 24,
-        right: 24,
+        left: 0,
+        right: 0,
         zIndex: 99999,
         elevation: 99999,
         alignItems: 'center',
@@ -180,7 +180,7 @@ const styles = StyleSheet.create({
         alignItems: 'center',
         paddingHorizontal: 12,
         paddingVertical: 10,
-        borderRadius: 12,
+        borderRadius: 28,
         borderWidth: 1,
         maxWidth: SCREEN_WIDTH - 80,
         shadowOffset: { width: 0, height: 4 },
@@ -197,10 +197,10 @@ const styles = StyleSheet.create({
         marginRight: 8,
     },
     message: {
-        flex: 1,
         fontSize: 14,
         lineHeight: 19,
         fontWeight: '500',
+        textAlign: 'center',
     },
 });
 

--- a/src/components/home/DailyUsageCard.tsx
+++ b/src/components/home/DailyUsageCard.tsx
@@ -189,7 +189,7 @@ const styles = StyleSheet.create({
     timeRow: {
         flexDirection: 'row',
         alignItems: 'baseline',
-        justifyContent: 'space-between',
+        gap: 6,
         marginBottom: 2,
     },
     digitalText: {

--- a/src/hooks/useLogin.ts
+++ b/src/hooks/useLogin.ts
@@ -120,11 +120,12 @@ export function useLogin({ t }: UseLoginProps) {
 
         setIsDirectLogging(true);
 
-        const apiClient = new ModemAPIClient(modemIp);
         let success = false;
 
         for (let attempt = 1; attempt <= 3; attempt++) {
             try {
+                // Fresh client per attempt — stale session/token from prior failure must not leak
+                const apiClient = new ModemAPIClient(modemIp);
                 console.log(`[Login Page] Attempt ${attempt}/3...`);
                 success = await apiClient.login(username, password);
 

--- a/src/services/ad.service.ts
+++ b/src/services/ad.service.ts
@@ -13,6 +13,7 @@ import { ThemedAlertHelper } from '@/components/ThemedAlert';
 import { ToastHelper } from '@/components/Toast';
 import { AdBlockAlertHelper } from '@/components/AdBlockAlertModal';
 import { useThemeStore } from '@/stores/theme.store';
+import { useAuthStore } from '@/stores/auth.store';
 import en from '@/i18n/en.json';
 import id from '@/i18n/id.json';
 
@@ -124,6 +125,8 @@ export function activateAdRequestCooldown(): void {
 
 function handleAdError(error: any) {
     if (!error) return;
+    // Only surface adblock prompt when user is authenticated — never on login page
+    if (!useAuthStore.getState().isAuthenticated) return;
     const errMsg = error?.message || String(error);
     if (errMsg.includes('doubleclick') || errMsg.includes('ad server') || errMsg.includes('Failed to connect')) {
         AdBlockAlertHelper.show();


### PR DESCRIPTION

- Login: create fresh ModemAPIClient per retry attempt to avoid stale session token/cookie leaking across retries (root cause of first-time login failure requiring manual profile add).
- ModalButton: add textAlign center + flexShrink so two-word titles stay horizontal and centered (fixes Apply Configuration button in BandSelectionModal and other ModalButton consumers).
- Changelog & AdBlock modals: only trigger after user is authenticated; previously fired on login page via startup checkAndShowChangelog and ad error handlers in ad.service.ts / AdBanner.tsx.