### PR TITLE
fix: button text single-line + faster realtime refresh

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -80,6 +80,9 @@ export const Button: React.FC<ButtonProps> = ({
               fontWeight: '600',
             },
           ]}
+          numberOfLines={1}
+          adjustsFontSizeToFit
+          minimumFontScale={0.8}
         >
           {title}
         </Text>

--- a/src/components/ModalButton.tsx
+++ b/src/components/ModalButton.tsx
@@ -62,15 +62,20 @@ export function ModalButton({
             {loading ? (
                 <BouncingDots size="small" color={getTextColor()} />
             ) : (
-                <Text style={[
-                    typography.headline,
-                    {
-                        color: getTextColor(),
-                        fontWeight: variant === 'secondary' ? '600' : 'bold',
-                        textAlign: 'center',
-                    },
-                    styles.text,
-                ]}>
+                <Text
+                    style={[
+                        typography.headline,
+                        {
+                            color: getTextColor(),
+                            fontWeight: variant === 'secondary' ? '600' : 'bold',
+                            textAlign: 'center',
+                        },
+                        styles.text,
+                    ]}
+                    numberOfLines={1}
+                    adjustsFontSizeToFit
+                    minimumFontScale={0.8}
+                >
                     {title}
                 </Text>
             )}

--- a/src/components/home/SpeedTestModal.tsx
+++ b/src/components/home/SpeedTestModal.tsx
@@ -666,7 +666,12 @@ export const SpeedTestModal: React.FC<SpeedTestModalProps> = ({ visible, onClose
                             style={[styles.actionButton, { backgroundColor: isRunning ? colors.error : colors.primary }]}
                             onPress={isRunning ? stopSpeedtest : phase === 'complete' ? handleClose : runSpeedtest}
                         >
-                            <Text style={[typography.body, { color: '#FFFFFF', fontWeight: '600' }]}>
+                            <Text
+                                style={[typography.body, { color: '#FFFFFF', fontWeight: '600', textAlign: 'center' }]}
+                                numberOfLines={1}
+                                adjustsFontSizeToFit
+                                minimumFontScale={0.8}
+                            >
                                 {isRunning ? t('common.stop') : phase === 'complete' ? t('common.ok') : t('home.startTest')}
                             </Text>
                         </TouchableOpacity>

--- a/src/hooks/home/useHomeData.ts
+++ b/src/hooks/home/useHomeData.ts
@@ -180,9 +180,9 @@ export function useHomeData({ t, showReloginWebView }: UseHomeDataProps) {
   const loadDataSilent = async (service: ModemService) => {
     try {
       const [signal, network, traffic, status, wan, dataStatus, modemInfo] = await Promise.all([
-        service.getSignalInfo().catch(() => null),
+        service.getSignalInfoFast().catch(() => null),
         service.getNetworkInfo().catch(() => null),
-        service.getTrafficStats().catch(() => null),
+        service.getTrafficStatsFast().catch(() => null),
         service.getModemStatus().catch(() => null),
         service.getWanInfo().catch(() => null),
         service.getMobileDataStatus().catch(() => null),
@@ -191,7 +191,18 @@ export function useHomeData({ t, showReloginWebView }: UseHomeDataProps) {
 
       if (signal) setSignalInfo(signal);
       if (network) setNetworkInfo(network);
-      if (traffic) setTrafficStats(traffic);
+      if (traffic) {
+        // Preserve month/day stats from last full fetch
+        const prev = useModemStore.getState().trafficStats;
+        if (prev) {
+          traffic.monthDownload = prev.monthDownload;
+          traffic.monthUpload = prev.monthUpload;
+          traffic.monthDuration = prev.monthDuration;
+          traffic.dayUsed = prev.dayUsed;
+          traffic.dayDuration = prev.dayDuration;
+        }
+        setTrafficStats(traffic);
+      }
       if (status) setModemStatus(status);
       if (wan) setWanInfo(wan);
       if (dataStatus) setMobileDataStatus(dataStatus);
@@ -233,8 +244,17 @@ export function useHomeData({ t, showReloginWebView }: UseHomeDataProps) {
 
   const loadTrafficOnly = async (service: ModemService) => {
     try {
-      const traffic = await service.getTrafficStats();
-      setTrafficStats(traffic);
+      const fast = await service.getTrafficStatsFast();
+      // Preserve month/day stats from last full fetch
+      const prev = useModemStore.getState().trafficStats;
+      if (prev) {
+        fast.monthDownload = prev.monthDownload;
+        fast.monthUpload = prev.monthUpload;
+        fast.monthDuration = prev.monthDuration;
+        fast.dayUsed = prev.dayUsed;
+        fast.dayDuration = prev.dayDuration;
+      }
+      setTrafficStats(fast);
     } catch (error) {
       console.error('Error loading traffic data:', error);
     }
@@ -311,13 +331,13 @@ export function useHomeData({ t, showReloginWebView }: UseHomeDataProps) {
         if (AppState.currentState === 'active') {
           loadTrafficOnly(service);
         }
-      }, 5000);
+      }, 3000);
 
       const fullDataIntervalId = setInterval(() => {
         if (AppState.currentState === 'active') {
           loadDataSilent(service);
         }
-      }, 15000);
+      }, 10000);
 
       return () => {
         clearInterval(trafficIntervalId);

--- a/src/services/modem.service.ts
+++ b/src/services/modem.service.ts
@@ -222,6 +222,39 @@ export class ModemService {
     }
   }
 
+  /**
+   * Fast traffic stats for realtime polling - uses getFast, skips month stats
+   * ponytail: month stats only fetched on full data interval, not every poll
+   */
+  async getTrafficStatsFast(): Promise<TrafficStats> {
+    try {
+      const safeParseInt = (value: string): number => {
+        const parsed = parseInt(value);
+        return isNaN(parsed) ? 0 : parsed;
+      };
+
+      const response = await this.apiClient.getFast('/api/monitoring/traffic-statistics');
+
+      return {
+        currentConnectTime: safeParseInt(parseXMLValue(response, 'CurrentConnectTime')),
+        currentUpload: safeParseInt(parseXMLValue(response, 'CurrentUpload')),
+        currentDownload: safeParseInt(parseXMLValue(response, 'CurrentDownload')),
+        currentDownloadRate: safeParseInt(parseXMLValue(response, 'CurrentDownloadRate')),
+        currentUploadRate: safeParseInt(parseXMLValue(response, 'CurrentUploadRate')),
+        totalUpload: safeParseInt(parseXMLValue(response, 'TotalUpload')),
+        totalDownload: safeParseInt(parseXMLValue(response, 'TotalDownload')),
+        totalConnectTime: safeParseInt(parseXMLValue(response, 'TotalConnectTime')),
+        monthDownload: 0,
+        monthUpload: 0,
+        monthDuration: 0,
+        dayUsed: 0,
+        dayDuration: 0,
+      };
+    } catch (error) {
+      throw error;
+    }
+  }
+
   async getModemStatus(): Promise<ModemStatus> {
     try {
       const response = await this.apiClient.get('/api/monitoring/status');


### PR DESCRIPTION
- Button/ModalButton/SpeedTestModal: numberOfLines=1 + adjustsFontSizeToFit
- Add getTrafficStatsFast() using getFast() (skip token/session overhead)
- loadDataSilent: use getSignalInfoFast + getTrafficStatsFast
- loadTrafficOnly: use getTrafficStatsFast, preserve month stats from prev
- Reduce traffic poll 5s→3s, full data poll 15s→10s