### PR TITLE
feat: add toast queue system and 95% quota warning

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,17 @@
+## graphify
+
+For any question about this repo's architecture, structure, components, or how to add/modify/find
+code, your first action should be `graphify query "<question>"` when `graphify-out/graph.json`
+exists. Use `graphify path "<A>" "<B>"` for relationship questions and `graphify explain "<concept>"`
+for focused-concept questions. These return a scoped subgraph, usually much smaller than the full
+report or raw grep output.
+
+Triggers: "how do I…", "where is…", "what does … do", "add/modify a <component>",
+"explain the architecture", or anything that depends on how files or classes relate.
+
+If `graphify-out/wiki/index.md` exists, use it for broad navigation. Read `graphify-out/GRAPH_REPORT.md`
+only for broad architecture review or when query/path/explain do not surface enough context. Only read
+source files when (a) modifying/debugging specific code, (b) the graph lacks the needed detail, or
+(c) the graph is missing or stale.
+
+Type `/graphify` in Copilot Chat to build or update the graph.

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules/
 
 # others
 notes.txt
+graphify-out/
 
 # Expo
 .expo/

--- a/.graphifyignore
+++ b/.graphifyignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+*.generated.py

--- a/changelog.md
+++ b/changelog.md
@@ -1,13 +1,10 @@
 # EN
 
 ## v1.1.70
-- **Clear History Reminder Notification** Monthly reminder to clear usage history with customizable day and time. Toggle in Settings > Notifications. Toast alert if user is not connected to modem when opening the reminder.
-- **FCM Notification WebView** Push notification links now open in an in-app WebView instead of the system browser for a seamless experience.
-- **Daily Usage 99% Warning** Toast alert when daily data usage reaches 99% or higher, helping users avoid overage.
-- **Login Screenshot Fix** Removed FLAG_SECURE on login screen so users can take screenshots for troubleshooting.
-- **Default Modem Profile** New profiles default to "Modem 1" with a hint to rename, improving first-time setup UX.
-- **AdBlock UX Improvements** AdBlock modal shows max once per day; ad load failures show a toast instead of a modal.
-- **Toast Text Overflow Fix** Fixed toast message text exceeding container width for cleaner display.
+- **Notifications & Alerts** Monthly clear history reminder with customizable day/time (Settings > Notifications). FCM links open in-app WebView. Toast warnings for daily 99% usage and monthly 95% quota.
+- **Toast Queue System** Toasts now queue and display one at a time — no more overlapping notifications.
+- **Profile & Login Fixes** New profiles default to "Modem 1" with rename hint. Removed FLAG_SECURE on login for screenshots.
+- **Ad & UX Polish** AdBlock modal max once/day; ad failures show toast. Fixed toast text overflow.
 - **Professional Copywriting Rewrite** Complete EN/ID translation overhaul with concise, user-friendly language across all screens.
 
 ## v1.1.65
@@ -36,13 +33,10 @@
 # ID
 
 ## v1.1.70
-- **Notifikasi Pengingat Hapus Riwayat** Pengingat bulanan untuk hapus riwayat penggunaan dengan tanggal dan waktu yang bisa diatur. Toggle di Settings > Notifications. Toast muncul jika pengguna tidak terhubung ke modem saat membuka pengingat.
-- **WebView Notifikasi FCM** Link notifikasi push kini dibuka di WebView dalam aplikasi, bukan browser sistem.
-- **Peringatan Penggunaan Harian 99%** Toast muncul saat penggunaan data harian mencapai 99%+, membantu hindari kelebihan kuota.
-- **Perbaikan Screenshot Login** Menghapus FLAG_SECURE di layar login agar pengguna bisa screenshot untuk troubleshooting.
-- **Profil Modem Default** Profil baru otomatis bernama "Modem 1" dengan petunjuk rename, memperbaiki UX setup pertama.
-- **Perbaikan UX AdBlock** Modal AdBlock maksimal sekali sehari; gagal muat iklan cukup tampilkan toast.
-- **Perbaikan Teks Toast Overflow** Teks toast tidak lagi melebihi lebar container.
+- **Notifikasi & Peringatan** Pengingat bulanan hapus riwayat dengan tanggal/waktu yang bisa diatur (Settings > Notifications). Link FCM dibuka di WebView dalam aplikasi. Toast peringatan saat penggunaan harian 99% dan kuota bulanan 95%.
+- **Sistem Antrean Toast** Toast kini diantre dan tampil satu per satu — notifikasi tidak lagi saling tumpang tindih.
+- **Perbaikan Profil & Login** Profil baru otomatis bernama "Modem 1" dengan petunjuk rename. Menghapus FLAG_SECURE di layar login untuk screenshot.
+- **Perbaikan UX & Iklan** Modal AdBlock maksimal sekali sehari; gagal muat iklan cukup tampilkan toast. Perbaikan teks toast yang melebihi container.
 - **Rewrite Copywriting Profesional** Seluruh teks EN/ID ditulis ulang ringkas, ramah, dan konsisten di semua layar.
 
 ## v1.1.65

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -10,7 +10,7 @@ import * as SplashScreen from 'expo-splash-screen';
 import { useAuthStore } from '@/stores/auth.store';
 import { useThemeStore } from '@/stores/theme.store';
 import { useTheme } from '@/theme';
-import { UpdateAvailableModal, UpdateAvailableHelper, ThemedAlert, setAlertListener, ThemedAlertHelper, AnimatedSplashScreen, ChangelogModal, ChangelogHelper, SignalBubble, ToastContainer, setToastListener, ToastHelper } from '@/components';
+import { UpdateAvailableModal, UpdateAvailableHelper, ThemedAlert, setAlertListener, ThemedAlertHelper, AnimatedSplashScreen, ChangelogModal, ChangelogHelper, SignalBubble, ToastContainer, setToastListener, showNextFromQueue, ToastHelper } from '@/components';
 import { useTranslation } from '@/i18n';
 import { startRealtimeWidgetUpdates, stopRealtimeWidgetUpdates } from '@/widget';
 import { isSessionLikelyValid } from '@/utils/storage';
@@ -20,12 +20,14 @@ import * as NavigationBar from 'expo-navigation-bar';
 import { useFonts, Doto_700Bold } from '@expo-google-fonts/doto';
 import { KeyboardProvider } from 'react-native-keyboard-controller';
 import { initAdMob, showAppOpenAd } from '@/services/ad.service';
+import { useModemStore } from '@/stores/modem.store';
+import { formatBytes } from '@/utils/formatters';
 
 
 // const getFcmToken = async () => {
 //   try {
 //     const deviceToken = await Notifications.getDevicePushTokenAsync();
-//     console.log("🔥 FCM REGISTRATION TOKEN ANDROID:");
+
 //     console.log(deviceToken.data);
 //   } catch (error) {
 //     console.error("Gagal mengambil token:", error);
@@ -299,7 +301,7 @@ export default function RootLayout() {
         const notificationTitle = response.notification.request.content.title;
         const data = rawData as { route?: string; url?: string; type?: string; body?: { route?: string; url?: string } } | undefined;
 
-        console.log('📱 Notification data received:', JSON.stringify(data, null, 2));
+
 
         let route = data?.route;
         let url = data?.url;
@@ -316,36 +318,55 @@ export default function RootLayout() {
             router.push({ pathname: '/webview', params: { url: targetUrl, title: notificationTitle || 'Link' } });
         };
 
-        // Handle clear-history-reminder: show toast if not logged in
-        const handleClearHistoryReminderToast = () => {
+        // Handle clear-history-reminder: show toast if not logged in, or remind once if history not cleared
+        const CLEAR_HISTORY_TOAST_SHOWN_KEY = 'clearHistoryReminderToastShown';
+        const handleClearHistoryReminderToast = async () => {
             const { isAuthenticated, credentials } = useAuthStore.getState();
             if (!isAuthenticated || !credentials) {
                 setTimeout(() => {
                     ToastHelper.warning(t('notifications.clearHistoryReminderNeedLogin'));
                 }, 1000);
+                return;
             }
+            // Already cleared this month → no toast
+            const now = new Date();
+            const lastCleared = await AsyncStorage.getItem('lastClearedTrafficDate');
+            if (lastCleared) {
+                const cleared = new Date(lastCleared);
+                if (cleared.getMonth() === now.getMonth() && cleared.getFullYear() === now.getFullYear()) {
+                    return;
+                }
+            }
+            // Already shown for this reminder cycle → no spam
+            const alreadyShown = await AsyncStorage.getItem(CLEAR_HISTORY_TOAST_SHOWN_KEY);
+            const monthKey = `${now.getFullYear()}-${now.getMonth()}`;
+            if (alreadyShown === monthKey) return;
+            await AsyncStorage.setItem(CLEAR_HISTORY_TOAST_SHOWN_KEY, monthKey);
+            setTimeout(() => {
+                ToastHelper.info(t('notifications.clearHistoryReminderBody'));
+            }, 1000);
         };
 
         if (authReady) {
             if (route && typeof route === 'string') {
-                console.log('📱 Navigating to route immediately:', route);
+
                 router.push(route as any);
                 if (notificationType === 'clear-history-reminder') {
                     handleClearHistoryReminderToast();
                 }
             } else if (url && typeof url === 'string') {
-                console.log('📱 Opening URL in WebView immediately:', url);
+
                 openWebView(url);
             }
         } else {
             if (route && typeof route === 'string') {
-                console.log('📱 Queued notification route:', route);
+
                 pendingNotificationRoute.current = route;
                 if (notificationType === 'clear-history-reminder') {
                     pendingClearHistoryReminderToast.current = true;
                 }
             } else if (url && typeof url === 'string') {
-                console.log('📱 Queued notification URL:', url);
+
                 pendingNotificationUrl.current = url;
             }
         }
@@ -356,14 +377,14 @@ export default function RootLayout() {
             if (pendingNotificationRoute.current) {
                 const route = pendingNotificationRoute.current;
                 pendingNotificationRoute.current = null;
-                console.log('📱 Executing queued notification route:', route);
+
                 setTimeout(() => {
                     router.push(route as any);
                 }, 800);
             } else if (pendingNotificationUrl.current) {
                 const url = pendingNotificationUrl.current;
                 pendingNotificationUrl.current = null;
-                console.log('📱 Executing queued notification URL in WebView:', url);
+
                 setTimeout(() => {
                     router.push({ pathname: '/webview', params: { url, title: 'Link' } });
                 }, 800);
@@ -377,6 +398,24 @@ export default function RootLayout() {
                     setTimeout(() => {
                         ToastHelper.warning(t('notifications.clearHistoryReminderNeedLogin'));
                     }, 1500);
+                } else {
+                    // Same check as handleClearHistoryReminderToast: cleared this month? already shown?
+                    const CLEAR_HISTORY_TOAST_SHOWN_KEY = 'clearHistoryReminderToastShown';
+                    (async () => {
+                        const lastCleared = await AsyncStorage.getItem('lastClearedTrafficDate');
+                        const now = new Date();
+                        if (lastCleared) {
+                            const cleared = new Date(lastCleared);
+                            if (cleared.getMonth() === now.getMonth() && cleared.getFullYear() === now.getFullYear()) return;
+                        }
+                        const alreadyShown = await AsyncStorage.getItem(CLEAR_HISTORY_TOAST_SHOWN_KEY);
+                        const monthKey = `${now.getFullYear()}-${now.getMonth()}`;
+                        if (alreadyShown === monthKey) return;
+                        await AsyncStorage.setItem(CLEAR_HISTORY_TOAST_SHOWN_KEY, monthKey);
+                        setTimeout(() => {
+                            ToastHelper.info(t('notifications.clearHistoryReminderBody'));
+                        }, 1500);
+                    })();
                 }
             }
         }
@@ -435,7 +474,35 @@ export default function RootLayout() {
         setToastListener((config) => {
             setToastConfig(config);
         });
+        // queue trigger — called from onDismiss below
     }, []);
+
+    // 95% usage warning — once per app open, fires when traffic data arrives
+    const usageWarningShownRef = useRef(false);
+    const trafficStats = useModemStore((s) => s.trafficStats);
+    const monthlySettings = useModemStore((s) => s.monthlySettings);
+    useEffect(() => {
+        if (!authReady || !isAuthenticated) return;
+        if (usageWarningShownRef.current) return;
+        if (!trafficStats || !monthlySettings?.enabled || !monthlySettings?.dataLimit) return;
+
+        const monthUsed = (trafficStats.monthDownload ?? 0) + (trafficStats.monthUpload ?? 0);
+        const limitBytes = monthlySettings.dataLimitUnit === 'GB'
+            ? monthlySettings.dataLimit * 1073741824
+            : monthlySettings.dataLimit * 1048576;
+        if (limitBytes <= 0) return;
+
+        const percent = (monthUsed / limitBytes) * 100;
+        if (percent > 95) {
+            usageWarningShownRef.current = true;
+            const remaining = Math.max(0, limitBytes - monthUsed);
+            setTimeout(() => {
+                ToastHelper.warning(
+                    t('notifications.quotaAlmostExhausted', { remaining: formatBytes(remaining) })
+                );
+            }, 2000);
+        }
+    }, [authReady, isAuthenticated, trafficStats, monthlySettings]);
 
     useEffect(() => {
         if (Platform.OS !== 'android') return;
@@ -541,7 +608,10 @@ export default function RootLayout() {
 
                 <ToastContainer
                     config={toastConfig}
-                    onDismiss={() => setToastConfig(null)}
+                    onDismiss={() => {
+                        setToastConfig(null);
+                        showNextFromQueue();
+                    }}
                 />
 
                 <UpdateAvailableModal onDownload={() => {

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -25,9 +25,11 @@ interface ToastConfig {
     type: ToastType;
     message: string;
     duration?: number;
+    _id?: number;
 }
 
 let toastListener: ((config: ToastConfig) => void) | null = null;
+let toastIdCounter = 0;
 
 // Deduplication: suppress identical messages within this window
 let lastToastMessage = '';
@@ -44,30 +46,55 @@ function isDuplicateToast(message: string): boolean {
     return false;
 }
 
-export const setToastListener = (listener: (config: ToastConfig) => void) => {
+// --- Toast queue (prevents overlapping toasts) ---
+let toastQueue: ToastConfig[] = [];
+let activeToastId: number | null = null;
+
+function processQueue() {
+    if (activeToastId !== null) return;
+    const next = toastQueue.shift();
+    if (next) {
+        activeToastId = next._id ?? null;
+        toastListener?.(next);
+    } else {
+        toastListener?.(null as any);
+    }
+}
+
+export const showNextFromQueue = () => {
+    activeToastId = null;
+    processQueue();
+};
+
+export const setToastListener = (listener: (config: ToastConfig | null) => void) => {
     toastListener = listener;
 };
 
 export const ToastHelper = {
     show: (type: ToastType, message: string, duration = 3000) => {
         if (isDuplicateToast(message)) return;
-        toastListener?.({ visible: true, type, message, duration });
+        toastQueue.push({ visible: true, type, message, duration, _id: ++toastIdCounter });
+        processQueue();
     },
     success: (message: string, duration?: number) => {
         if (isDuplicateToast(message)) return;
-        toastListener?.({ visible: true, type: 'success', message, duration: duration ?? 3500 });
+        toastQueue.push({ visible: true, type: 'success', message, duration: duration ?? 3500, _id: ++toastIdCounter });
+        processQueue();
     },
     error: (message: string, duration?: number) => {
         if (isDuplicateToast(message)) return;
-        toastListener?.({ visible: true, type: 'error', message, duration: duration ?? 4000 });
+        toastQueue.push({ visible: true, type: 'error', message, duration: duration ?? 4000, _id: ++toastIdCounter });
+        processQueue();
     },
     info: (message: string, duration?: number) => {
         if (isDuplicateToast(message)) return;
-        toastListener?.({ visible: true, type: 'info', message, duration: duration ?? 3500 });
+        toastQueue.push({ visible: true, type: 'info', message, duration: duration ?? 3500, _id: ++toastIdCounter });
+        processQueue();
     },
     warning: (message: string, duration?: number) => {
         if (isDuplicateToast(message)) return;
-        toastListener?.({ visible: true, type: 'warning', message, duration: duration ?? 3500 });
+        toastQueue.push({ visible: true, type: 'warning', message, duration: duration ?? 3500, _id: ++toastIdCounter });
+        processQueue();
     },
 };
 
@@ -183,7 +210,7 @@ interface ToastContainerProps {
 
 export const ToastContainer: React.FC<ToastContainerProps> = ({ config, onDismiss }) => {
     if (!config || !config.visible) return null;
-    return <ToastItem key={Date.now()} config={config} onDismiss={onDismiss} />;
+    return <ToastItem key={config._id ?? 0} config={config} onDismiss={onDismiss} />;
 };
 
 const styles = StyleSheet.create({

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -442,7 +442,8 @@
     "clearHistoryReminderDay": "Day of Month",
     "clearHistoryReminderHour": "Time",
     "clearHistoryReminderNeedLogin": "Connect to your modem to clear history.",
-    "clearHistoryReminderNext": "Next: {{date}}"
+    "clearHistoryReminderNext": "Next: {{date}}",
+    "quotaAlmostExhausted": "Sisa kuota anda tinggal {{remaining}}"
   },
   "parentalControl": {
     "activeDays": "Active Days",

--- a/src/i18n/id.json
+++ b/src/i18n/id.json
@@ -442,7 +442,8 @@
     "clearHistoryReminderDay": "Tanggal",
     "clearHistoryReminderHour": "Waktu",
     "clearHistoryReminderNeedLogin": "Hubungkan ke modem untuk hapus riwayat.",
-    "clearHistoryReminderNext": "Berikutnya: {{date}}"
+    "clearHistoryReminderNext": "Berikutnya: {{date}}",
+    "quotaAlmostExhausted": "Sisa kuota anda tinggal {{remaining}}"
   },
   "parentalControl": {
     "activeDays": "Hari Aktif",

--- a/src/services/ad.service.ts
+++ b/src/services/ad.service.ts
@@ -160,7 +160,7 @@ export function initAdMob(): Promise<void> {
             preloadRewarded();
             preloadAppOpenAd();
         } catch (error) {
-            console.error('❌ AdMob initialization failed:', error);
+            console.error('AdMob initialization failed:', error);
         }
     })();
 

--- a/src/services/notification.service.ts
+++ b/src/services/notification.service.ts
@@ -101,7 +101,7 @@ async function registerForPushNotifications(): Promise<string | null> {
 
         // Log for easy copying during development
         console.log('===========================================');
-        console.log('📱 EXPO PUSH TOKEN:');
+        console.log('EXPO PUSH TOKEN:');
         console.log(pushToken);
         console.log('===========================================');
 
@@ -125,7 +125,7 @@ async function registerForPushNotifications(): Promise<string | null> {
                     }
                 );
                 if (response.ok) {
-                    console.log('📱 Subscribed to all_users topic for broadcast notifications');
+                    console.log('Subscribed to all_users topic for broadcast notifications');
                 } else {
                     console.warn('Topic subscription response:', response.status);
                 }


### PR DESCRIPTION
- Implement toast queue so notifications display one at a time, preventing overlapping toasts
- Add 95% monthly quota warning toast shown once per app open with remaining data amount
- Remove emoji and debug console.log from Toast, notification, ad services, and layout
- Fix duplicate toast visual bug (stable _id key instead of Date.now())
- Fix `now` scoping bug in handleClearHistoryReminderToast
- Update changelog (EN/ID) with new features