### PR TITLE
fix: resolve screen dimming on modal open, localize feedback URL, and adjust sound toggle

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -104,7 +104,7 @@ Menemukan bug atau punya saran?
   Sertakan model modem, versi firmware, dan screenshot jika bisa.
 
 - **Via Formulir Web**:
-  Kirim feedback cepat melalui [**formulir online ini**](https://hm.cakson.my.id/#support).
+  Kirim feedback cepat melalui [**formulir online ini**](https://hm.cakson.my.id/en/#feedback).
 
 ---
 

--- a/src/app/(tabs)/settings/index.tsx
+++ b/src/app/(tabs)/settings/index.tsx
@@ -446,7 +446,8 @@ export default function SettingsIndex() {
                         onSelect={(val) => {
                             setShowBugReportModal(false);
                             if (val === 'website') {
-                                router.push({ pathname: '/webview', params: { url: 'https://hm.cakson.my.id/#support', title: t('settings.bugReport') || 'Bug Report' } });
+                                const feedbackUrl = language === 'id' ? 'https://hm.cakson.my.id/id/#feedback' : 'https://hm.cakson.my.id/en/#feedback';
+                                router.push({ pathname: '/webview', params: { url: feedbackUrl, title: t('settings.bugReport') || 'Bug Report' } });
                             } else {
                                 router.push({ pathname: '/webview', params: { url: 'https://github.com/alrescha79-cmd/huawei-manager-mobile/issues/new?assignees=alrescha79-cmd&labels=bug&projects=&template=bug_report.md', title: t('settings.bugReport') || 'Bug Report' } });
                             }

--- a/src/app/(tabs)/sms.tsx
+++ b/src/app/(tabs)/sms.tsx
@@ -261,6 +261,8 @@ export default function SMSScreen() {
         visible={showCompose}
         animationType="slide"
         presentationStyle="pageSheet"
+        transparent
+        statusBarTranslucent
         onRequestClose={() => setShowCompose(false)}
       >
         <StatusBar backgroundColor={colors.background} barStyle={isDark ? 'light-content' : 'dark-content'} />

--- a/src/components/BandSelectionModal.tsx
+++ b/src/components/BandSelectionModal.tsx
@@ -226,6 +226,8 @@ export function BandSelectionModal({
             visible={visible}
             animationType="slide"
             presentationStyle="pageSheet"
+            transparent
+            statusBarTranslucent
             onRequestClose={handleClose}
         >
             <MeshGradientBackground style={styles.container}>

--- a/src/components/ChangelogModal.tsx
+++ b/src/components/ChangelogModal.tsx
@@ -197,6 +197,7 @@ export const ChangelogModal: React.FC<ChangelogModalProps> = () => {
         <Modal
             visible={visible}
             transparent
+            statusBarTranslucent
             animationType="none"
             onRequestClose={handleClose}
         >

--- a/src/components/MonthlySettingsModal.tsx
+++ b/src/components/MonthlySettingsModal.tsx
@@ -145,6 +145,8 @@ export function MonthlySettingsModal({
             visible={visible}
             animationType="slide"
             presentationStyle="pageSheet"
+            transparent
+            statusBarTranslucent
             onRequestClose={handleClose}
         >
             <MeshGradientBackground style={styles.modalContainer}>

--- a/src/components/PageSheetModal.tsx
+++ b/src/components/PageSheetModal.tsx
@@ -61,6 +61,7 @@ export function PageSheetModal({
             animationType="slide"
             presentationStyle="overFullScreen"
             transparent
+            statusBarTranslucent
             onRequestClose={handleClose}
         >
             <MeshGradientBackground style={styles.container}>

--- a/src/components/SelectionModal.tsx
+++ b/src/components/SelectionModal.tsx
@@ -45,6 +45,7 @@ export function SelectionModal({
             visible={visible}
             animationType="fade"
             transparent={true}
+            statusBarTranslucent
             onRequestClose={onClose}
         >
             <View style={styles.modalOverlay}>

--- a/src/components/SignalPointingModal.tsx
+++ b/src/components/SignalPointingModal.tsx
@@ -503,6 +503,27 @@ export function SignalPointingModal({ visible, onClose }: SignalPointingModalPro
                             </TouchableOpacity>
                         </Card>
 
+                        <TouchableOpacity
+                            style={[styles.soundToggle, {
+                                backgroundColor: soundEnabled ? colors.primary : (isDark ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.05)'),
+                                marginTop: spacing.md,
+                            }]}
+                            onPress={() => setSoundEnabled(!soundEnabled)}
+                        >
+                            <MaterialIcons
+                                name={soundEnabled ? 'vibration' : 'notifications-off'}
+                                size={24}
+                                color={soundEnabled ? '#FFFFFF' : colors.textSecondary}
+                            />
+                            <Text style={[typography.body, {
+                                color: soundEnabled ? '#FFFFFF' : colors.text,
+                                marginLeft: 8,
+                                fontWeight: '600',
+                            }]}>
+                                {t('home.vibrationFeedback')}: {soundEnabled ? 'ON' : 'OFF'}
+                            </Text>
+                        </TouchableOpacity>
+
                         {/* Tips - Standard positioning (hidden when external antenna selected) */}
                         {antennaMode !== 'external' && (
                             <Card style={{ marginTop: spacing.md, backgroundColor: isDark ? 'rgba(52,199,89,0.1)' : 'rgba(52,199,89,0.05)' }}>
@@ -554,27 +575,6 @@ export function SignalPointingModal({ visible, onClose }: SignalPointingModalPro
                                 </View>
                             </Card>
                         )}
-
-                        <TouchableOpacity
-                            style={[styles.soundToggle, {
-                                backgroundColor: soundEnabled ? colors.primary : (isDark ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.05)'),
-                                marginTop: spacing.md,
-                            }]}
-                            onPress={() => setSoundEnabled(!soundEnabled)}
-                        >
-                            <MaterialIcons
-                                name={soundEnabled ? 'vibration' : 'notifications-off'}
-                                size={24}
-                                color={soundEnabled ? '#FFFFFF' : colors.textSecondary}
-                            />
-                            <Text style={[typography.body, {
-                                color: soundEnabled ? '#FFFFFF' : colors.text,
-                                marginLeft: 8,
-                                fontWeight: '600',
-                            }]}>
-                                {t('home.vibrationFeedback')}: {soundEnabled ? 'ON' : 'OFF'}
-                            </Text>
-                        </TouchableOpacity>
                     </>
                 )}
             </ScrollView>

--- a/src/components/ThemedAlert.tsx
+++ b/src/components/ThemedAlert.tsx
@@ -52,6 +52,7 @@ export const ThemedAlert: React.FC<ThemedAlertProps> = ({
         <Modal
             visible={visible}
             transparent
+            statusBarTranslucent
             animationType="fade"
             onRequestClose={onDismiss}
         >

--- a/src/components/UpdateAvailableModal.tsx
+++ b/src/components/UpdateAvailableModal.tsx
@@ -90,7 +90,7 @@ export const UpdateAvailableModal: React.FC<UpdateAvailableModalProps> = ({ onDo
     });
 
     return (
-        <Modal visible={visible} transparent animationType="none" onRequestClose={handleClose}>
+        <Modal visible={visible} transparent statusBarTranslucent animationType="none" onRequestClose={handleClose}>
             <View style={styles.overlay}>
                 <TouchableWithoutFeedback onPress={handleClose}>
                     <Animated.View style={[

--- a/src/components/WebViewLogin.tsx
+++ b/src/components/WebViewLogin.tsx
@@ -257,9 +257,10 @@ export function WebViewLogin({
     return (
         <Modal
             visible={visible}
-            animationType={hidden ? "fade" : "slide"}
+            animationType={hidden ? "none" : "slide"}
             presentationStyle={hidden ? "overFullScreen" : "fullScreen"}
             transparent={hidden}
+            statusBarTranslucent
             onRequestClose={handleClose}
         >
             {hidden ? (

--- a/src/components/home/DiagnosisResultModal.tsx
+++ b/src/components/home/DiagnosisResultModal.tsx
@@ -43,6 +43,7 @@ export function DiagnosisResultModal({
             visible={visible}
             animationType="fade"
             transparent={true}
+            statusBarTranslucent
             onRequestClose={handleClose}
         >
             <View style={styles.overlay}>

--- a/src/components/home/NoSignalModal.tsx
+++ b/src/components/home/NoSignalModal.tsx
@@ -79,6 +79,7 @@ export const NoSignalModal: React.FC<NoSignalModalProps> = ({
         <Modal
             visible={sheetVisible}
             transparent
+            statusBarTranslucent
             animationType="none"
             onRequestClose={() => { }}
         >

--- a/src/components/home/SpeedTestModal.tsx
+++ b/src/components/home/SpeedTestModal.tsx
@@ -552,7 +552,7 @@ export const SpeedTestModal: React.FC<SpeedTestModalProps> = ({ visible, onClose
     });
 
     return (
-        <Modal visible={visible} transparent animationType="fade" onRequestClose={handleClose}>
+        <Modal visible={visible} transparent statusBarTranslucent animationType="fade" onRequestClose={handleClose}>
             <View style={styles.overlay}>
                 <View style={[styles.modalContent, {
                     backgroundColor: isDark ? '#1C1C1E' : '#FFFFFF',

--- a/src/components/settings/ApnModal.tsx
+++ b/src/components/settings/ApnModal.tsx
@@ -130,6 +130,8 @@ export function ApnModal({
             visible={visible}
             animationType="slide"
             presentationStyle="pageSheet"
+            transparent
+            statusBarTranslucent
             onRequestClose={handleClose}
         >
             <View style={[styles.modalContainer, { backgroundColor: colors.background }]}>

--- a/src/components/settings/ProfileEditModal.tsx
+++ b/src/components/settings/ProfileEditModal.tsx
@@ -128,6 +128,8 @@ export function ProfileEditModal({
             visible={visible}
             animationType="slide"
             presentationStyle="pageSheet"
+            transparent
+            statusBarTranslucent
             onRequestClose={handleClose}
         >
             <View style={[styles.modalContainer, { backgroundColor: colors.background }]}>

--- a/src/components/settings/ReleaseNotesModal.tsx
+++ b/src/components/settings/ReleaseNotesModal.tsx
@@ -440,6 +440,7 @@ export function ReleaseNotesModal({
             animationType="slide"
             presentationStyle="overFullScreen"
             transparent
+            statusBarTranslucent
             onRequestClose={onClose}
         >
             <MeshGradientBackground>

--- a/src/components/sms/SMSDetailModal.tsx
+++ b/src/components/sms/SMSDetailModal.tsx
@@ -62,6 +62,8 @@ export function SMSDetailModal({
             visible={visible}
             animationType="slide"
             presentationStyle="pageSheet"
+            transparent
+            statusBarTranslucent
             onRequestClose={handleClose}
         >
             <StatusBar backgroundColor={colors.background} barStyle={isDark ? 'light-content' : 'dark-content'} />

--- a/src/components/wifi/DeviceDetailModal.tsx
+++ b/src/components/wifi/DeviceDetailModal.tsx
@@ -135,6 +135,8 @@ export function DeviceDetailModal({
             visible={visible}
             animationType="slide"
             presentationStyle="pageSheet"
+            transparent
+            statusBarTranslucent
             onRequestClose={onClose}
         >
             <MeshGradientBackground style={styles.modalContainer}>

--- a/src/components/wifi/ParentalProfileModal.tsx
+++ b/src/components/wifi/ParentalProfileModal.tsx
@@ -141,6 +141,8 @@ export function ParentalProfileModal({
             visible={visible}
             animationType="slide"
             presentationStyle="pageSheet"
+            transparent
+            statusBarTranslucent
             onRequestClose={handleClose}
         >
             <MeshGradientBackground style={styles.modalContainer}>


### PR DESCRIPTION
## Summary
- **Android Screen Dimming**: Added `transparent` and `statusBarTranslucent` properties across all modal components to prevent native window `FLAG_DIM_BEHIND` and status bar decor desync on Android devices.
- **Feedback URL**: Localized bug report/feedback URL based on current language setting (`/id/#feedback` for Indonesian, `/en/#feedback` for others).
- **Signal Pointing UX**: Moved the vibration/sound toggle button directly below antenna settings and above positioning tips.