### PR TITLE
fix(android): resolve black screen, dim persistence, and BTS API env inlining in release builds

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -127,7 +127,18 @@ jobs:
             echo "android/ directory exists — skipping expo prebuild to preserve manual native changes"
           else
             echo "android/ not found — running expo prebuild"
-            npx expo prebuild --platform android
+            npx expo prebuild --platform android --clean
+          fi
+
+      - name: Verify environment variables
+        run: |
+          echo "BTS_API_URL is set: $([ -n "$EXPO_PUBLIC_BTS_API_URL" ] && echo 'YES' || echo 'NO')"
+          echo "BTS_API_KEY is set: $([ -n "$EXPO_PUBLIC_BTS_API_KEY" ] && echo 'YES' || echo 'NO')"
+          if [ -z "$EXPO_PUBLIC_BTS_API_URL" ]; then
+            echo "::warning::EXPO_PUBLIC_BTS_API_URL is not set — BTS lookups via bts.cakson will be skipped"
+          fi
+          if [ -z "$EXPO_PUBLIC_BTS_API_KEY" ]; then
+            echo "::warning::EXPO_PUBLIC_BTS_API_KEY is not set — BTS lookups via bts.cakson will be skipped"
           fi
 
       - name: Ensure debug keystore exists

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -91,6 +91,17 @@ jobs:
       - name: Prebuild Android
         run: npx expo prebuild --platform android --clean
 
+      - name: Verify environment variables
+        run: |
+          echo "BTS_API_URL is set: $([ -n "$EXPO_PUBLIC_BTS_API_URL" ] && echo 'YES' || echo 'NO')"
+          echo "BTS_API_KEY is set: $([ -n "$EXPO_PUBLIC_BTS_API_KEY" ] && echo 'YES' || echo 'NO')"
+          if [ -z "$EXPO_PUBLIC_BTS_API_URL" ]; then
+            echo "::warning::EXPO_PUBLIC_BTS_API_URL is not set — BTS lookups via bts.cakson will be skipped"
+          fi
+          if [ -z "$EXPO_PUBLIC_BTS_API_KEY" ]; then
+            echo "::warning::EXPO_PUBLIC_BTS_API_KEY is not set — BTS lookups via bts.cakson will be skipped"
+          fi
+
       - name: Ensure debug keystore exists
         run: |
           # expo prebuild --clean may not create debug.keystore on CI,

--- a/app.config.ts
+++ b/app.config.ts
@@ -40,7 +40,7 @@ export default ({ config }: ConfigContext): ExpoConfig => {
         ...config,
         name: isDev ? 'HM Mobile [DEV]' : 'Huawei Manager',
         slug: 'hm-mobile',
-        version: '1.1.75',
+        version: '1.1.80',
         orientation: 'portrait',
         icon: './assets/logo.png',
         userInterfaceStyle: 'automatic',
@@ -56,6 +56,62 @@ export default ({ config }: ConfigContext): ExpoConfig => {
                         // Shrink release APKs: R8 code shrinking + resource stripping.
                         enableProguardInReleaseBuilds: true,
                         enableShrinkResourcesInReleaseBuilds: true,
+                        // Keep critical library classes from being stripped by R8.
+                        extraProguardRules: `# React Native core
+-keep class com.facebook.react.** { *; }
+-keep class com.facebook.react.turbomodule.** { *; }
+-keep class com.facebook.react.bridge.** { *; }
+-keep class com.facebook.react.module.annotations.** { *; }
+-keep class * implements com.facebook.react.bridge.NativeModule { *; }
+-keep class * extends com.facebook.react.bridge.ReactContextBaseJavaModule { *; }
+
+# React Native Reanimated
+-keep class com.swmansion.reanimated.** { *; }
+
+# React Native Google Mobile Ads
+-keep class com.google.android.gms.ads.** { *; }
+-keep class com.google.android.gms.common.** { *; }
+-keep class com.google.android.gms.internal.ads.** { *; }
+-keep class com.google.android.** { *; }
+-keep class com.google.ads.** { *; }
+-dontwarn com.google.android.gms.ads.**
+
+# Expo modules
+-keep class expo.modules.** { *; }
+-keep class org.unimodules.** { *; }
+-dontwarn expo.modules.**
+
+# React Native Firebase
+-keep class io.invertase.firebase.** { *; }
+-dontwarn io.invertase.firebase.**
+
+# React Native WebView
+-keep class com.reactnativecommunity.webview.** { *; }
+-keep class com.reactnative.webview.** { *; }
+
+# React Native Android Widget
+-keep class com.reactnativeandroidwidget.** { *; }
+
+# React Native Gesture Handler
+-keep class com.swmansion.gesturehandler.** { *; }
+
+# React Native Screens
+-keep class com.swmansion.rnscreens.** { *; }
+
+# React Native SVG
+-keep class com.horcrux.svg.** { *; }
+
+# Keep enums, annotations, and Kotlin metadata
+-keepattributes *Annotation*
+-keepattributes Signature
+-keepattributes InnerClasses
+-keepattributes EnclosingMethod
+-keep class kotlin.Metadata { *; }
+-dontwarn kotlin.**
+
+# App package
+-keep class com.alrescha79.hmmobile.** { *; }
+`,
                     },
                 },
             ],

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,12 @@
 # EN
 
+## v1.1.80
+- **Android Screen Dimming Fix** Resolved an issue on certain Android devices where screen brightness dropped or dimmed on launch in release builds by automatically clearing stale WindowManager flags upon resume.
+- **BTS Locator API & Quota Optimization** Migrated cell tower coordinate resolution from bundled local CSV to a dedicated remote BTS API mirror with API key authentication, dynamic env configuration, and graceful rate-limit handling (429) with retry cooldowns. Free geolocation sources are prioritized to preserve API quota.
+- **Dynamic Map Theme Integration** BTS Locator and WebView map layers now automatically adapt to light/dark themes and accent color settings in real time.
+- **Tab Badges & Background Polling** Fixed the WiFi tab badge not appearing upon initial startup by polling connected devices in the background right from the home screen.
+- **Mock SMS Testing Mode** Added mock SMS support to facilitate UI and badge testing on modems without native SMS capabilities.
+
 ## v1.1.75
 - **BTS Locator Feature** Added a dedicated interactive BTS Locator map to find the connected cell tower and visualize nearby 2G (GSM), 3G (UMTS), 4G (LTE), and 5G (NR) towers within a 20 km radius, with seamless fallback to remote data when the local database misses.
 - **UI/UX & Privacy Enhancements**
@@ -40,6 +47,13 @@
 - **Background Resource & Ad Optimization** Suspends background updates and widget polling to save battery when backgrounded, with capped App Open ad frequency and improved interstitial flow.
 
 # ID
+
+## v1.1.80
+- **Perbaikan Layar Meredup Android** Mengatasi bug pada beberapa perangkat Android di mana kecerahan layar turun/meredup saat membuka aplikasi hasil build rilis, dengan membersihkan flag WindowManager secara otomatis saat aplikasi dibuka kembali.
+- **Migrasi API BTS & Penghematan Kuota** Mengganti database CSV lokal dengan mirror API BTS jarak jauh berbasis autentikasi API key, konfigurasi URL dinamis melalui env, serta penanganan batas request (rate limit 429) dengan sistem cooldown. Sumber geolokasi gratis diprioritaskan untuk menghemat kuota API.
+- **Pewarnaan Peta Otomatis Mengikuti Tema** Peta BTS Locator dan WebView kini otomatis menyesuaikan mode terang/gelap serta warna aksen aplikasi secara real-time.
+- **Perbaikan Badge Tab WiFi & Polling Latar Belakang** Memperbaiki badge angka pada tab WiFi yang sebelumnya tidak muncul saat awal buka aplikasi dengan memuat data perangkat terhubung secara berkala dari layar utama.
+- **Mode Mock SMS untuk Pengujian** Menambahkan kembali data mock SMS agar antarmuka SMS dan badge pesan belum dibaca dapat diuji pada modem yang tidak mendukung SMS.
 
 ## v1.1.75
 - **Fitur Baru BTS Locator** Menambahkan peta interaktif BTS Locator untuk melacak posisi menara BTS yang sedang terhubung serta menampilkan persebaran BTS 2G (GSM), 3G (UMTS), 4G (LTE), dan 5G (NR) terdekat dalam radius 20 km, lengkap dengan fallback ke data online saat database lokal tidak menemukan hasil.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hm-mobile",
-  "version": "1.1.75",
+  "version": "1.1.80",
   "main": "index.js",
   "scripts": {
     "start": "expo start",

--- a/plugins/with-clear-dim-flags.js
+++ b/plugins/with-clear-dim-flags.js
@@ -7,10 +7,19 @@
 // stale dim/brightness persists until the activity is recreated (force-stop),
 // which users see as "the screen dims on open until I restart the app".
 //
-// The plugin patches MainActivity to reset that window state whenever the
-// activity resumes or regains window focus (i.e. right after any overlay
-// window — dialog, ad activity — closes). It also clears FLAG_SECURE, matching
-// the manual edit the dev build has, so CI prebuilds keep the same behavior.
+// The plugin patches MainActivity to clear that window state whenever the
+// activity regains window focus (i.e. right after any overlay window — dialog,
+// ad activity — closes). It also clears FLAG_SECURE, matching the manual edit
+// the dev build has, so CI prebuilds keep the same behavior.
+//
+// IMPORTANT: We do NOT call resetWindowDimState() in onResume() because that
+// fires before the splash screen is dismissed and before any closing overlay
+// has fully detached, which can cause a black/blank screen on some OEM ROMs.
+// Instead, we only clear flags in onWindowFocusChanged(true), which fires
+// after the overlay window has completely closed and focus returns to the
+// activity. We also never SET FLAG_DIM_BEHIND (no toggle) — setting it even
+// momentarily causes a visible dim flash or persistent black screen on
+// certain devices.
 'use strict';
 
 const { withMainActivity } = require('@expo/config-plugins');
@@ -18,11 +27,6 @@ const { withMainActivity } = require('@expo/config-plugins');
 const ANCHOR = 'override fun getMainComponentName(): String = "main"';
 
 const WINDOW_RESET = `
-  override fun onResume() {
-    super.onResume()
-    resetWindowDimState()
-  }
-
   override fun onWindowFocusChanged(hasFocus: Boolean) {
     super.onWindowFocusChanged(hasFocus)
     if (hasFocus) {
@@ -32,15 +36,13 @@ const WINDOW_RESET = `
 
   private fun resetWindowDimState() {
     try {
-      val dimFlag = android.view.WindowManager.LayoutParams.FLAG_DIM_BEHIND
-      window.clearFlags(dimFlag)
-      // Toggle the flag once to force WindowManager to recompose its dim
-      // layer stack; some OEM ROMs otherwise keep the dim layer attached to
-      // the activity after an overlay window closes.
-      window.setFlags(dimFlag, dimFlag)
-      window.clearFlags(dimFlag)
+      // Only CLEAR flags — never SET FLAG_DIM_BEHIND, even momentarily.
+      // Setting it (even to "toggle") causes a dim flash or black screen
+      // on MIUI/ColorOS because the dim layer is composited before clear.
+      window.clearFlags(android.view.WindowManager.LayoutParams.FLAG_DIM_BEHIND)
       // Some OEMs or libraries set FLAG_SECURE; explicitly clear it here.
       window.clearFlags(android.view.WindowManager.LayoutParams.FLAG_SECURE)
+      // Reset screenBrightness to system default if an ad/overlay overrode it.
       val attrs = window.attributes
       if (attrs.screenBrightness in 0f..1f) {
         attrs.screenBrightness = -1f

--- a/src/services/btsService.ts
+++ b/src/services/btsService.ts
@@ -49,8 +49,14 @@ export interface BtsRateLimit {
     retryAfterSeconds: number;
 }
 
-const BTS_API_BASE = process.env.EXPO_PUBLIC_BTS_API_URL;
-const BTS_API_KEY = process.env.EXPO_PUBLIC_BTS_API_KEY;
+// Read env vars at call-time, not at module load. In production builds,
+// babel-preset-expo inlines EXPO_PUBLIC_* as string literals at build time,
+// so these getters resolve to the inlined value. In development, they read
+// process.env at runtime. Moving to getters (instead of module-scope consts)
+// ensures the values are always fresh and avoids stale-undefined issues if
+// the module is imported before env is populated.
+const getBtsApiBase = (): string => process.env.EXPO_PUBLIC_BTS_API_URL || '';
+const getBtsApiKey = (): string => process.env.EXPO_PUBLIC_BTS_API_KEY || '';
 const ACTIVE_TOWER_URL = 'https://api.frexello.com/api/active-tower';
 const MLS_URL = 'https://location.services.mozilla.com/v1/geolocate';
 const GOOGLE_GEOLOCATION_URL = 'https://www.googleapis.com/geolocation/v1/geolocate';
@@ -98,7 +104,9 @@ const fetchWithTimeout = (url: string, options: RequestInit, timeoutMs: number):
 const apiGet = async <T>(endpoint: string, params: Record<string, string | number | undefined>): Promise<T | null> => {
     // URL comes from env (EXPO_PUBLIC_BTS_API_URL) — without it the backend is
     // unavailable, so skip every bts.cakson call.
+    const BTS_API_BASE = getBtsApiBase();
     if (!BTS_API_BASE) return null;
+    const BTS_API_KEY = getBtsApiKey();
     // Respect the backend 30 req/min/IP limit locally so we stop hammering it
     // once the server told us we're out of quota.
     if (getBtsRateLimit()) return null;


### PR DESCRIPTION
## Summary

Fixes three root causes that made release builds worse than before.

---

### 1. Blank/black screen on app open

**Root cause:** The `with-clear-dim-flags` plugin was calling `setFlags(FLAG_DIM_BEHIND)` as a "toggle" before `clearFlags()`. This actually **activates the dim layer momentarily**. On MIUI/ColorOS, the dim layer doesn't always clear after `clearFlags()`, causing a persistent black screen. Additionally, `onResume()` fired before the splash screen was dismissed, compounding the issue.

**Fix:**
- Remove `onResume()` override entirely
- Remove `setFlags(dimFlag, dimFlag)` toggle — only use `clearFlags(FLAG_DIM_BEHIND)`
- Only reset window state in `onWindowFocusChanged(true)` (after overlay/ad fully closes)

### 2. BTS API env vars not inlined in CI builds

**Root cause:** `btsService.ts` read `process.env.EXPO_PUBLIC_BTS_API_URL` at **module scope**. In production builds, `babel-preset-expo` inlines `EXPO_PUBLIC_*` as string literals at build time. If env vars were missing during Metro bundling, values were inlined as `undefined`, causing all BTS API calls to be silently skipped.

**Fix:**
- Move env var reads to **runtime getter functions** (`getBtsApiBase()`, `getBtsApiKey()`)
- Add `--clean` flag to `expo prebuild` in `build-release.yml` (was missing)
- Add **env verification step** in both workflows to warn if secrets are empty before building

### 3. R8/ProGuard stripping critical library classes

**Root cause:** `enableProguardInReleaseBuilds: true` + `enableShrinkResourcesInReleaseBuilds: true` were enabled, but `proguard-rules.pro` only kept 2 classes (`reanimated`, `turbomodule`). R8 could strip classes from AdMob, Expo modules, Firebase, WebView, etc., causing crashes and blank screens.

**Fix:**
- Add `extraProguardRules` via `expo-build-properties` in `app.config.ts` (so it survives `expo prebuild --clean` on CI)
- Keep rules for: React Native core, Reanimated, Google Mobile Ads, Expo modules, Firebase, WebView, Widget, GestureHandler, Screens, SVG, Kotlin metadata, app package
- Keep attributes: `*Annotation*`, `Signature`, `InnerClasses`, `EnclosingMethod`

---

## Files changed

| File | Change |
|------|--------|
| `plugins/with-clear-dim-flags.js` | Remove `onResume()`, remove `setFlags` toggle, only `clearFlags` in `onWindowFocusChanged` |
| `src/services/btsService.ts` | Move env reads from module scope to runtime getters |
| `app.config.ts` | Add `extraProguardRules` to `expo-build-properties` |
| `.github/workflows/build-release.yml` | Add `--clean` to prebuild, add env verification step |
| `.github/workflows/build-test.yml` | Add env verification step |

## Test plan

- [ ] Trigger `Build Test APK` workflow on this branch — verify env vars show "YES" in verification step
- [ ] Install test APK — open app — no black screen
- [ ] Open BTS Locator — verify tower data loads from bts.cakson
- [ ] Open app, let App Open Ad show, close it — no dim/black screen
- [ ] Background app, resume — no dim/black screen