### PR TITLE
fix(ci): upgrade Node 20→22 and remove expo-github-action

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Setup Java
@@ -107,13 +107,6 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
-
-      - name: Setup Expo
-        uses: expo/expo-github-action@v8
-        with:
-          expo-version: latest
-          eas-version: latest
-          token: ${{ secrets.EXPO_TOKEN }}
 
       - name: Set version code
         run: echo "ANDROID_VERSION_CODE=$(( ${{ github.run_number }} * 10 + ${{ matrix.version_code_offset }} ))" >> $GITHUB_ENV

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Setup Java
@@ -63,13 +63,6 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
-
-      - name: Setup Expo
-        uses: expo/expo-github-action@v8
-        with:
-          expo-version: latest
-          eas-version: latest
-          token: ${{ secrets.EXPO_TOKEN }}
 
       - name: Get version and branch info
         id: get_info


### PR DESCRIPTION
## Summary

Fixes CI build failure caused by Node 20 deprecation and expo-github-action.

### Root cause

`expo-github-action@v8` installs global `expo-cli` and `eas-cli` via yarn. `eas-cli@22` depends on `@oclif/plugin-autocomplete@3.3.0` which requires **Node >=22**, but the workflow was using **Node 20** — causing `Found incompatible module` exit code 1.

Additionally, **Node 20 is deprecated** on GitHub Actions runners as of Sep 2025.

### Fix

- Upgrade `node-version` from `'20'` to `'22'` in both workflows
- Remove `expo-github-action@v8` step entirely — the build only uses `npx expo prebuild` (from local `node_modules`) and `gradlew assembleRelease`, so global `expo-cli`/`eas-cli` are not needed

### Error log

```
error @oclif/plugin-autocomplete@3.3.0: The engine "node" is incompatible with this module.
Expected version ">=22.0.0". Got "20.20.2"
error Found incompatible module.
##[error]The process '/usr/local/bin/yarn' failed with exit code 1
```

## Files changed

| File | Change |
|------|--------|
| `.github/workflows/build-test.yml` | Node 20→22, remove expo-github-action step |
| `.github/workflows/build-release.yml` | Node 20→22, remove expo-github-action step |
