### PR TITLE
feat(bts): switch to OpenStreetMap tiles, add resolution logging & update v1.1.80 changelog

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,10 +1,17 @@
 # EN
 
 ## v1.1.80
-- **Android Screen Dimming Fix** Resolved an issue on certain Android devices where screen brightness dropped or dimmed on launch in release builds by automatically clearing stale WindowManager flags upon resume.
-- **BTS Locator API & Quota Optimization** Migrated cell tower coordinate resolution from bundled local CSV to a dedicated remote BTS API mirror with API key authentication, dynamic env configuration, and graceful rate-limit handling (429) with retry cooldowns. Free geolocation sources are prioritized to preserve API quota.
-- **Dynamic Map Theme Integration** BTS Locator and WebView map layers now automatically adapt to light/dark themes and accent color settings in real time.
+- **Native In-App Feedback Form** Replaced external redirect with a native Bug Report & Feature Request screen in Settings, featuring automatic modem model detection, smooth keyboard handling, and direct API submission.
+- **BTS Locator Enhancements & OpenStreetMap**
+  - Switched map tile provider to 100% free and open-source OpenStreetMap (OSM) with seamless dark mode support.
+  - Added real-time device compass heading with an animated directional radar beam cone on the modem marker.
+  - Significantly sped up initial screen loading by fetching only the connected BTS tower first.
+  - Added on-demand lazy loading for nearby towers on map zoom-out (zoom $\le$ 13) with a floating loading indicator.
+  - Added visual warning alerts and debug logging for estimated versus exact cell tower coordinates.
+- **BTS API & Quota Optimization** Migrated cell tower coordinate resolution from bundled local CSV to a dedicated remote BTS API mirror with API key authentication, dynamic environment configuration, and graceful rate-limit handling (429) with retry cooldowns. Free geolocation sources are prioritized to preserve API quota.
+- **Android Screen Dimming & Display Fixes** Resolved release build issues on certain Android devices where screen brightness dropped or dimmed upon launch or modal interactions by automatically resetting WindowManager flags.
 - **Tab Badges & Background Polling** Fixed the WiFi tab badge not appearing upon initial startup by polling connected devices in the background right from the home screen.
+- **Session & Stability Improvements** Stabilized API client session handling, XML parsing, and data hooks for more reliable modem communication.
 - **Mock SMS Testing Mode** Added mock SMS support to facilitate UI and badge testing on modems without native SMS capabilities.
 
 ## v1.1.75
@@ -49,10 +56,17 @@
 # ID
 
 ## v1.1.80
-- **Perbaikan Layar Meredup Android** Mengatasi bug pada beberapa perangkat Android di mana kecerahan layar turun/meredup saat membuka aplikasi hasil build rilis, dengan membersihkan flag WindowManager secara otomatis saat aplikasi dibuka kembali.
-- **Migrasi API BTS & Penghematan Kuota** Mengganti database CSV lokal dengan mirror API BTS jarak jauh berbasis autentikasi API key, konfigurasi URL dinamis melalui env, serta penanganan batas request (rate limit 429) dengan sistem cooldown. Sumber geolokasi gratis diprioritaskan untuk menghemat kuota API.
-- **Pewarnaan Peta Otomatis Mengikuti Tema** Peta BTS Locator dan WebView kini otomatis menyesuaikan mode terang/gelap serta warna aksen aplikasi secara real-time.
+- **Form Feedback & Laporan Bug Dalam Aplikasi** Mengganti tautan web eksternal dengan formulir Laporan Bug & Permintaan Fitur langsung di dalam aplikasi (Pengaturan > Umpan Balik), lengkap dengan deteksi otomatis model modem aktif dan pengiriman langsung via API.
+- **Penyempurnaan BTS Locator & OpenStreetMap**
+  - Mengganti penyedia peta ke OpenStreetMap (OSM) yang 100% gratis dan open-source dengan dukungan tema gelap otomatis.
+  - Menambahkan arah kompas (heading) real-time dengan efek visual radar beam pada penanda modem.
+  - Mempercepat waktu buka awal peta dengan hanya memuat koordinat BTS yang sedang terhubung terlebih dahulu.
+  - Menambahkan pemuatan cerdas (on-demand lazy load) untuk menara BTS sekitar saat peta di-zoom out (zoom $\le$ 13) disertai indikator status melayang.
+  - Menambahkan peringatan visual dan pencatatan log resolusi apakah BTS yang terhubung merupakan koordinat asli (persis/sektor) atau estimasi terdekat.
+- **Optimalisasi API BTS & Penghematan Kuota** Mengganti database CSV lokal dengan mirror API BTS jarak jauh berbasis autentikasi API key, konfigurasi dinamis melalui env, serta penanganan batas request (rate limit 429) dengan sistem cooldown. Sumber geolokasi gratis diprioritaskan untuk menghemat kuota API.
+- **Perbaikan Layar Meredup Android** Mengatasi bug pada beberapa perangkat Android di mana kecerahan layar turun/meredup saat membuka aplikasi atau menutup dialog modal pada build rilis, dengan membersihkan flag WindowManager secara otomatis.
 - **Perbaikan Badge Tab WiFi & Polling Latar Belakang** Memperbaiki badge angka pada tab WiFi yang sebelumnya tidak muncul saat awal buka aplikasi dengan memuat data perangkat terhubung secara berkala dari layar utama.
+- **Peningkatan Sesi & Stabilitas Modem** Menyempurnakan penanganan sesi klien API, parsing respons XML, dan data hooks agar komunikasi dengan modem lebih stabil dan tahan gangguan.
 - **Mode Mock SMS untuk Pengujian** Menambahkan kembali data mock SMS agar antarmuka SMS dan badge pesan belum dibaca dapat diuji pada modem yang tidak mendukung SMS.
 
 ## v1.1.75

--- a/src/app/bts-locator.tsx
+++ b/src/app/bts-locator.tsx
@@ -212,6 +212,16 @@ export default function BtsLocatorScreen() {
             setDistanceM(calculateDistanceKm(user.lat, user.lon, bts.lat, bts.lon) * 1000);
             setBearing(normalizeBearing(calculateBearing(user.lat, user.lon, bts.lat, bts.lon)));
 
+            const statusLabel = bts.source === 'api'
+                ? 'Asli (Exact Cell Match)'
+                : bts.source === 'enodeb'
+                ? 'Asli (Sector eNodeB Match)'
+                : bts.source === 'site'
+                ? 'Estimasi/Terdekat (Near-miss Site Estimate)'
+                : `Sumber Eksternal (${bts.source})`;
+
+            console.log(`[BTS Locator] Koordinat BTS Terhubung: lat=${bts.lat}, lon=${bts.lon} | Status: ${statusLabel} | Source: ${bts.source}`);
+
             if (bts.source === 'site') {
                 ToastHelper.warning(tRef.current('bts.estimatedAlertBody'));
             }

--- a/src/components/BtsMapWebView.tsx
+++ b/src/components/BtsMapWebView.tsx
@@ -78,6 +78,7 @@ const buildHtml = (p: ThemeParams): string => `
 <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
 <style>
   html, body, #map { margin: 0; padding: 0; height: 100%; width: 100%; background: ${p.bg}; }
+  ${p.isDark ? '.leaflet-tile-pane { filter: invert(100%) hue-rotate(180deg) brightness(90%) contrast(90%); }' : ''}
   .leaflet-popup-content-wrapper, .leaflet-popup-tip { background: ${p.popupBg}; color: ${p.text}; box-shadow: 0 4px 14px rgba(0,0,0,${p.isDark ? '0.5' : '0.15'}); }
   .leaflet-popup-content { font: 12px/1.5 system-ui, sans-serif; margin: 10px 12px; }
   .leaflet-container { background: ${p.bg}; }
@@ -197,7 +198,10 @@ const buildHtml = (p: ThemeParams): string => `
   function initMap() {
     if (map) return;
     map = L.map('map', { zoomControl: true, attributionControl: false }).setView([-6.2, 106.816], 6);
-    L.tileLayer('${p.tileUrl}', { maxZoom: 19 }).addTo(map);
+    L.tileLayer('${p.tileUrl}', {
+      maxZoom: 19,
+      attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+    }).addTo(map);
     userMarker = L.marker([-6.2, 106.816], { icon: modemIcon() }).addTo(map);
     btsMarker = L.marker([-6.2, 106.816], { icon: towerIcon() }).addTo(map);
     line = L.polyline([], { color: '${p.primary}', dashArray: '6,8', weight: 2, opacity: 0.9 }).addTo(map);
@@ -325,9 +329,7 @@ export function BtsMapWebView({ userLocation, btsLocation, btsInfo, nearbyTowers
             warning: colors.warning,
             error: colors.error,
             barOff: isDark ? '#3a3a44' : '#cbd5e1',
-            tileUrl: isDark
-                ? 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png'
-                : 'https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png',
+            tileUrl: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
             modemFrameStroke: isDark ? '#8a95a5' : '#cbd5e1',
             towerFrameStroke: isDark ? '#ffffff' : '#0f172a',
         }),

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -23,7 +23,7 @@
     "estimatedAlertTitle": "Estimated Location",
     "estimatedAlertBody": "Exact coordinates for the connected tower were not found in the database. The marker shown is an estimate from the nearest tower.",
     "betaDisclaimer": "This feature is currently in beta and not 100% accurate due to limited BTS coordinate data.",
-    "loadingNearby": "Loading nearby towers...",
+    "loadingNearby": "Loading nearby towers",
     "popupTitle": "Connected Tower",
     "nearbyTitle": "Nearby Tower",
     "fromYou": "from you",

--- a/src/i18n/id.json
+++ b/src/i18n/id.json
@@ -23,7 +23,7 @@
     "estimatedAlertTitle": "Posisi Perkiraan",
     "estimatedAlertBody": "Lokasi persis menara yang terhubung tidak ditemukan di database online. Titik yang ditampilkan adalah perkiraan posisi menara terdekat.",
     "betaDisclaimer": "Fitur ini masih dalam tahap beta dan belum 100% akurat karena keterbatasan data titik koordinat BTS.",
-    "loadingNearby": "Memuat BTS sekitar...",
+    "loadingNearby": "Memuat BTS sekitar",
     "popupTitle": "Menara Terhubung",
     "nearbyTitle": "Menara BTS",
     "fromYou": "dari Anda",

--- a/src/services/btsService.ts
+++ b/src/services/btsService.ts
@@ -254,10 +254,16 @@ export const fetchBtsCoordinates = async (
     const isIndonesia = mcc === '510';
 
     const google = await scrapeGoogleGeolocation(mcc, normMnc, cellId, lac);
-    if (google) return google;
+    if (google) {
+        console.log(`[BTS Service] Koordinat ditemukan via Google Geolocation (Asli): lat=${google.lat}, lon=${google.lon}`);
+        return google;
+    }
 
     const mozilla = await scrapeMozilla(mcc, normMnc, cellId, lac);
-    if (mozilla) return mozilla;
+    if (mozilla) {
+        console.log(`[BTS Service] Koordinat ditemukan via Mozilla (Asli): lat=${mozilla.lat}, lon=${mozilla.lon}`);
+        return mozilla;
+    }
 
     if (isIndonesia) {
         // Exact lookup if TAC is provided
@@ -269,6 +275,7 @@ export const fetchBtsCoordinates = async (
                 ci: cellId,
             });
             if (tower && typeof tower.tower_lat === 'number' && typeof tower.tower_lon === 'number') {
+                console.log(`[BTS Service] Koordinat ditemukan via Exact Lookup (Asli/CellID Match): lat=${tower.tower_lat}, lon=${tower.tower_lon}`);
                 return { lat: tower.tower_lat, lon: tower.tower_lon, source: 'api' };
             }
         }
@@ -288,18 +295,21 @@ export const fetchBtsCoordinates = async (
             // Exact cell match (closest if duplicate)
             const exact = nearby.find((t) => t.ci === cellId);
             if (exact) {
+                console.log(`[BTS Service] Koordinat ditemukan via Nearby Towers (Asli/CellID Match ${cellId}): lat=${exact.tower_lat}, lon=${exact.tower_lon}`);
                 return { lat: exact.tower_lat, lon: exact.tower_lon, source: 'api' };
             }
 
             // Same eNodeB (sector match)
             const byEnodeB = nearby.find((t) => Math.floor(t.ci / 256) === eNodeB);
             if (byEnodeB) {
+                console.log(`[BTS Service] Koordinat ditemukan via Same eNodeB (Asli/Sector Match eNodeB ${eNodeB}): lat=${byEnodeB.tower_lat}, lon=${byEnodeB.tower_lon}`);
                 return { lat: byEnodeB.tower_lat, lon: byEnodeB.tower_lon, source: 'enodeb' };
             }
 
             // Near-miss eNodeB (|delta| <= 50)
             const site = nearby.find((t) => Math.abs(Math.floor(t.ci / 256) - eNodeB) <= 50);
             if (site) {
+                console.log(`[BTS Service] Koordinat merupakan Estimasi/Terdekat (Near-miss Site eNodeB ${Math.floor(site.ci / 256)} ~ ${eNodeB}): lat=${site.tower_lat}, lon=${site.tower_lon}`);
                 return { lat: site.tower_lat, lon: site.tower_lon, source: 'site' };
             }
         }
@@ -307,8 +317,12 @@ export const fetchBtsCoordinates = async (
 
     // Fallback: frexello active-tower lookup (works with or without TAC).
     const activeTower = await scrapeActiveTower(mcc, normMnc, cellId, lac);
-    if (activeTower) return activeTower;
+    if (activeTower) {
+        console.log(`[BTS Service] Koordinat ditemukan via Active Tower API: lat=${activeTower.lat}, lon=${activeTower.lon}`);
+        return activeTower;
+    }
 
+    console.log(`[BTS Service] BTS tidak ditemukan untuk CellID ${cellId}, MCC ${mcc}, MNC ${normMnc}, TAC ${lac ?? '-'}`);
     return null;
 };
 


### PR DESCRIPTION
## Summary

1. **OpenStreetMap Migration**:
   - Switched map tile provider from CARTO to 100% free and open-source OpenStreetMap (`https://tile.openstreetmap.org/{z}/{x}/{y}.png`).
   - Implemented CSS dark-mode invert/contrast filter on Leaflet tile layer so map automatically matches system dark mode without distorting markers/overlays.
   - Included required OSM attribution.

2. **Tower Resolution Logging**:
   - Added detailed debug logs indicating whether the connected BTS coordinate is an exact match (`Asli / Exact Cell Match`), a sector match (`Asli / Sector eNodeB Match`), or an estimate (`Estimasi / Near-miss Site Estimate`).

3. **Changelog**:
   - Updated `changelog.md` (EN & ID) with full release notes for **v1.1.80**.